### PR TITLE
feat: Implement PPU basics, DMG background rendering, and test framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+image = "0.24"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,10 @@ mod joypad;
 mod serial;
 mod timer;
 
+use std::env; // For command-line arguments
 use std::fs::File; // Added for file operations
 use std::io::{Read, Result}; // Added for file operations and Result type
+use std::path::Path; // For path manipulation
 use std::rc::Rc;
 use std::cell::RefCell;
 
@@ -35,11 +37,22 @@ fn load_rom_file(path: &str) -> Result<Vec<u8>> {
 fn main() {
     println!("GBC Emulator starting...");
 
-    // Define the path to the ROM
-    let rom_path = "roms/cpu_instrs.gb"; // Path to the ROM file
+    // Parse command-line arguments for ROM path
+    let args: Vec<String> = env::args().collect();
+    let default_rom_path = "roms/cpu_instrs.gb".to_string();
+    let rom_path = if args.len() > 1 {
+        args[1].clone()
+    } else {
+        println!("Usage: {} <path_to_rom>", args[0]);
+        println!("Defaulting to ROM: {}", default_rom_path);
+        // std::process::exit(1); // Optionally exit if no ROM is provided
+        default_rom_path
+    };
+    println!("Loading ROM from: {}", rom_path);
+
 
     // Load the ROM data from the file
-    let rom_data = match load_rom_file(rom_path) {
+    let rom_data = match load_rom_file(&rom_path) {
         Ok(data) => data,
         Err(e) => {
             // If the user needs to supply the ROM, it's better to panic here.
@@ -69,14 +82,60 @@ fn main() {
 
     println!("Initial CPU state: PC=0x{:04X}, SP=0x{:04X}, A=0x{:02X}, F=0x{:02X}", cpu.pc, cpu.sp, cpu.a, cpu.f);
 
-    const MAX_STEPS: u64 = 5_000_000; // Define a maximum number of steps for the emulation loop
-    const SERIAL_PRINT_INTERVAL: u64 = 100_000;
+    // Test ROM specific configurations
+    let test_check_addr = 0x6000; // For Blargg's test status
+    let blargg_test_running_magic_val = 0x80; // Blargg's tests write 0x80 here while running.
+    // let blargg_test_string_addr = 0x6004; // Start of Blargg's test result string
+    // let newer_blargg_test_string_addr = 0xA004; // Some newer tests use this
+
+    const MAX_STEPS: u64 = 30_000_000; // Increased max steps for longer tests
+    const SERIAL_PRINT_INTERVAL: u64 = 500_000; // Adjusted for potentially longer tests
+    let mut blargg_test_passed = false;
+    let mut blargg_test_failed_code: Option<u8> = None;
 
     for i in 0..MAX_STEPS {
-        cpu.step(); // Execute one CPU step
+        let m_cycles = cpu.step(); // Execute one CPU step and get M-cycles
 
+        // PPU runs 4 times faster than CPU M-cycles (T-cycles = M-cycles * 4)
+        let t_cycles = m_cycles * 4;
+        for _ in 0..t_cycles {
+            bus.borrow_mut().ppu.tick();
+            // TODO: PPU could request VBlank/STAT interrupts here
+            // Example: if bus.borrow().ppu.vblank_interrupt_requested() {
+            //              bus.borrow_mut().request_interrupt(Interrupt::VBlank);
+            //          }
+        }
+
+        // Check for Blargg test completion via memory mapped status
+        let status = bus.borrow().read_byte(test_check_addr);
+        if status != 0x00 && status != blargg_test_running_magic_val {
+            println!(
+                "Test status at {:#06X}: {:#04X}. Assuming test complete.",
+                test_check_addr, status
+            );
+            if status == 0x01 { // Typical pass code for Blargg's tests
+                blargg_test_passed = true;
+                println!("Blargg Test: PASSED (Code 0x01 at {:#06X})", test_check_addr);
+            } else {
+                blargg_test_failed_code = Some(status);
+                println!("Blargg Test: FAILED (Code {:#04X} at {:#06X})", status, test_check_addr);
+            }
+            // TODO: Read optional string output from 0x6004 or 0xA004
+            break;
+        }
+
+        // Check for halt condition (could be end of non-Blargg test or other issue)
         if cpu.is_halted {
             println!("CPU Halted at step {}.", i + 1);
+            // Check if it's the typical Blargg infinite loop: JR -2 (0x18, 0xFE)
+            // This usually means the test is done and waiting.
+            let current_opcode = bus.borrow().read_byte(cpu.pc.wrapping_sub(2)); // Opcode of JR
+            let operand = bus.borrow().read_byte(cpu.pc.wrapping_sub(1));     // Operand of JR
+            if current_opcode == 0x18 && operand == 0xFE {
+                 println!("CPU Halted in typical Blargg test infinite loop (JR -2).");
+                 // If status at 0x6000 is still 0x80 (running), it means test might rely on serial output
+                 // or visual check. For now, just break.
+            }
             break;
         }
 
@@ -84,8 +143,6 @@ fn main() {
             let serial_data = bus.borrow().get_serial_output_string();
             if !serial_data.is_empty() {
                 println!("Serial Output (step {}):\n{}", i + 1, serial_data);
-                // Optionally clear serial_output after printing if desired
-                // bus.borrow_mut().serial_output.clear();
             }
             println!("Current CPU state (step {}): PC=0x{:04X}, SP=0x{:04X}, A=0x{:02X}, F=0x{:02X}, B=0x{:02X}, C=0x{:02X}, D=0x{:02X}, E=0x{:02X}, H=0x{:02X}, L=0x{:02X}",
                      i + 1, cpu.pc, cpu.sp, cpu.a, cpu.f, cpu.b, cpu.c, cpu.d, cpu.e, cpu.h, cpu.l);
@@ -96,12 +153,38 @@ fn main() {
         }
     }
 
+    // After loop actions
+    println!("\n--- Emulation Loop Ended ---");
+
+    if blargg_test_passed {
+        println!("Overall Test Result: PASSED");
+    } else if let Some(code) = blargg_test_failed_code {
+        println!("Overall Test Result: FAILED (Code: {:#04X})", code);
+    } else {
+        println!("Overall Test Result: UNKNOWN (Test did not write a conclusive status or was interrupted).");
+    }
+
+    // Save screenshot
+    let rom_filename_stem = Path::new(&rom_path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown_rom");
+    let screenshot_path = format!("test_output_{}.png", rom_filename_stem);
+
+    println!("Saving screenshot to {}...", screenshot_path);
+    match bus.borrow().ppu.save_framebuffer_to_png(&bus.borrow().ppu.framebuffer, 160, 144, &screenshot_path) {
+        Ok(_) => println!("Screenshot saved successfully."),
+        Err(e) => eprintln!("Failed to save screenshot: {}", e),
+    }
+
     // Final serial output check
     let serial_data = bus.borrow().get_serial_output_string();
     if !serial_data.is_empty() {
-        println!("Final Serial Output:\n{}", serial_data);
+        println!("\nFinal Serial Output:\n{}", serial_data);
     }
 
-    println!("Final CPU state: PC=0x{:04X}, is_halted: {}", cpu.pc, cpu.is_halted);
+    println!("\nFinal CPU state: PC=0x{:04X}, SP=0x{:04X}, A=0x{:02X}, F=0x{:02X}, B=0x{:02X}, C=0x{:02X}, D=0x{:02X}, E=0x{:02X}, H=0x{:02X}, L=0x{:02X}",
+             cpu.pc, cpu.sp, cpu.a, cpu.f, cpu.b, cpu.c, cpu.d, cpu.e, cpu.h, cpu.l);
+    println!("CPU is_halted: {}", cpu.is_halted);
     println!("GBC Emulator finished.");
 }

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -1,24 +1,452 @@
 // src/ppu.rs
+use image::{ImageBuffer, ImageError, RgbImage};
+
+// DMG Palette Colors (RGB)
+const COLOR_WHITE: [u8; 3] = [0xFF, 0xFF, 0xFF];
+const COLOR_LIGHT_GRAY: [u8; 3] = [0xAA, 0xAA, 0xAA];
+const COLOR_DARK_GRAY: [u8; 3] = [0x55, 0x55, 0x55];
+const COLOR_BLACK: [u8; 3] = [0x00, 0x00, 0x00];
+
+const DMG_PALETTE: [[u8; 3]; 4] = [
+    COLOR_WHITE,
+    COLOR_LIGHT_GRAY,
+    COLOR_DARK_GRAY,
+    COLOR_BLACK,
+];
+
+// PPU Mode timings
+const OAM_SCAN_CYCLES: u32 = 80;
+const DRAWING_CYCLES: u32 = 172;
+const HBLANK_CYCLES: u32 = 204;
+const SCANLINE_CYCLES: u32 = OAM_SCAN_CYCLES + DRAWING_CYCLES + HBLANK_CYCLES; // 456
+const VBLANK_LINES: u8 = 10;
+const LINES_PER_FRAME: u8 = 144 + VBLANK_LINES; // 154
+
+// PPU Modes (for STAT register bits 0-1)
+const MODE_HBLANK: u8 = 0;
+const MODE_VBLANK: u8 = 1;
+const MODE_OAM_SCAN: u8 = 2;
+const MODE_DRAWING: u8 = 3;
 
 pub struct Ppu {
-    // Add PPU-specific fields here later
+    pub vram: [u8; 8192], // Video RAM
+    pub oam: [u8; 160],   // Object Attribute Memory
+    pub framebuffer: Vec<u8>, // Stores pixels for the current frame (160x144 pixels, 3 bytes per pixel for RGB)
+    pub cycles: u32,      // Cycles elapsed in the current scanline
+    pub lcdc: u8,         // LCD Control (0xFF40)
+    pub stat: u8,         // LCD Status (0xFF41)
+    // Bit 7: LCD Display Enable
+    // Bit 6: Window Tile Map Display Select (0=9800-9BFF, 1=9C00-9FFF)
+    // Bit 5: Window Display Enable
+    // Bit 4: BG & Window Tile Data Select (0=8800-97FF, 1=8000-8FFF)
+    // Bit 3: BG Tile Map Display Select (0=9800-9BFF, 1=9C00-9FFF)
+    // Bit 2: OBJ (Sprite) Size (0=8x8, 1=8x16)
+    // Bit 1: OBJ (Sprite) Display Enable
+    // Bit 0: BG/Window Display Enable (0=Off, 1=On)
+
+    // STAT Register (0xFF41)
+    // Bits 0-1: PPU Mode (0: HBlank, 1: VBlank, 2: OAM Scan, 3: Drawing)
+    // Bit 2: LYC == LY Flag
+    // Bit 3: Mode 0 HBlank Interrupt Enable
+    // Bit 4: Mode 1 VBlank Interrupt Enable
+    // Bit 5: Mode 2 OAM Interrupt Enable
+    // Bit 6: LYC == LY Interrupt Enable
+    // Bit 7: Unused (Always 1?) - Some docs say this bit is fixed 1.
+
+    pub scy: u8,          // Scroll Y (0xFF42)
+    pub scx: u8,          // Scroll X (0xFF43)
+    pub ly: u8,           // LCD Y Coordinate (0xFF44) - Current scanline being processed
+    pub lyc: u8,          // LY Compare (0xFF45)
+    pub bgp: u8,          // Background Palette Data (0xFF47)
+    pub obp0: u8,         // Object Palette 0 Data (0xFF48)
+    pub obp1: u8,         // Object Palette 1 Data (0xFF49)
+    pub wy: u8,           // Window Y Position (0xFF4A)
+    pub wx: u8,           // Window X Position (0xFF4B)
 }
 
 impl Ppu {
     pub fn new() -> Self {
-        Self {
-            // Initialize PPU-specific fields here later
+        // Initialize STAT: Mode 2 (OAM Scan) typically, LYC=LY flag might be set if LYC=0.
+        // Bit 7 is often read as 1.
+        // For simplicity, start in Mode 0 (HBLANK) as LY=0, Cycles=0 will transition it.
+        // Or start in Mode 2, as LY=0, Cycles=0 implies start of a scanline.
+        // Let's set initial mode to OAM_SCAN (2) as if frame is just starting.
+        // And LYC=LY flag (bit 2) if ly (0) == lyc (0).
+        let initial_ly = 0;
+        let initial_lyc = 0;
+        let mut initial_stat = MODE_OAM_SCAN; // Mode 2
+        if initial_ly == initial_lyc {
+            initial_stat |= 1 << 2; // Set LYC=LY flag
+        }
+        // Bit 7 of STAT is often fixed to 1
+        initial_stat |= 1 << 7;
+
+
+        Ppu {
+            vram: [0; 8192],
+            oam: [0; 160],
+            framebuffer: vec![0; 160 * 144 * 3], // Initialize with black pixels
+            cycles: 0,
+            lcdc: 0x91, // Typical boot value
+            stat: initial_stat,
+            scy: 0,
+            scx: 0,
+            ly: initial_ly,
+            lyc: initial_lyc,
+            bgp: 0xFC, // Typical boot value
+            obp0: 0xFF, // Typical boot value
+            obp1: 0xFF, // Typical boot value
+            wy: 0,
+            wx: 0,
         }
     }
 
+    // Helper to set PPU mode in STAT register
+    fn set_mode(&mut self, mode: u8) {
+        // Clear bits 0-1 and then set them to the new mode
+        self.stat = (self.stat & 0b1111_1100) | mode;
+    }
+
+    // Helper to check LYC=LY condition and update STAT
+    fn check_lyc_ly(&mut self) {
+        if self.ly == self.lyc {
+            self.stat |= (1 << 2); // Set LYC=LY flag (Bit 2)
+            // TODO: Trigger LYC interrupt if STAT bit 6 is enabled
+        } else {
+            self.stat &= !(1 << 2); // Clear LYC=LY flag
+        }
+    }
+
+    pub fn tick(&mut self) {
+        // Tick is assumed to be called for each PPU cycle (T-cycle)
+
+        // LCD Power Check - if LCD is off, PPU does nothing, LY resets to 0, mode to 0 (HBlank)
+        if self.lcdc & (1 << 7) == 0 { // Bit 7 is LCD Display Enable
+            self.cycles = 0;
+            self.ly = 0;
+            self.set_mode(MODE_HBLANK); // Mode 0
+            // STAT LYC=LY flag should still be updated.
+            self.check_lyc_ly();
+            // Framebuffer might be cleared or show white. For now, no explicit clear here.
+            return;
+        }
+
+        self.cycles += 1; // Assuming 1 tick call = 1 PPU cycle. Adjust if PPU gets more cycles at once.
+
+        if self.ly >= 144 { // VBlank period (Lines 144-153)
+            self.set_mode(MODE_VBLANK); // Mode 1
+            if self.cycles >= SCANLINE_CYCLES {
+                self.cycles = 0;
+                self.ly += 1;
+                if self.ly >= LINES_PER_FRAME { // End of VBlank
+                    self.ly = 0; // Reset for new frame
+                    // Transition to Mode 2 (OAM Scan) for the new frame's first line.
+                    self.set_mode(MODE_OAM_SCAN);
+                    // TODO: Clear VBLANK interrupt flag if it was set by PPU
+                }
+                self.check_lyc_ly(); // LYC=LY check happens on LY changes
+            }
+        } else { // Scanlines 0-143 (Visible frame)
+            let current_mode = self.stat & 0b11;
+
+            if self.cycles < OAM_SCAN_CYCLES { // Mode 2 - OAM Scan
+                if current_mode != MODE_OAM_SCAN {
+                    self.set_mode(MODE_OAM_SCAN);
+                    // TODO: OAM interrupt logic if enabled
+                }
+            } else if self.cycles < OAM_SCAN_CYCLES + DRAWING_CYCLES { // Mode 3 - Drawing
+                if current_mode != MODE_DRAWING {
+                    self.set_mode(MODE_DRAWING);
+                    // Render scanline on first cycle of Mode 3
+                    self.render_scanline();
+                }
+            } else if self.cycles < SCANLINE_CYCLES { // Mode 0 - HBlank
+                 if current_mode != MODE_HBLANK {
+                    self.set_mode(MODE_HBLANK);
+                    // TODO: HBlank interrupt logic if enabled
+                }
+            } else { // End of a scanline
+                self.cycles = 0;
+                self.ly += 1;
+                self.check_lyc_ly(); // LYC=LY check happens on LY changes
+
+                if self.ly == 144 { // Transition to VBlank
+                    self.set_mode(MODE_VBLANK);
+                    // TODO: Trigger VBlank interrupt (set IF register bit 0 if IE register bit 0 is set)
+
+                    // Save framebuffer at the start of VBlank
+                    // This is done only once per frame, when ly first becomes 144.
+                    // Ensure this is the *actual* first cycle of this line in VBlank.
+                    // The mode transition to VBLANK happens right before this check.
+                    // The `cycles` would have just been reset to 0 from the previous line's completion.
+                    // So, this is a good spot if we assume tick() is called per PPU cycle.
+                    // However, the current logic sets mode to VBLANK and then increments LY.
+                    // Let's adjust the screenshot trigger to be when LY becomes 144 AND mode becomes VBLANK.
+                    // The current structure of tick():
+                    //  - line 143 finishes, cycles reset, ly becomes 144.
+                    //  - check_lyc_ly() called.
+                    //  - Then, if ly == 144, set_mode(MODE_VBLANK)
+                    // This means the screenshot should be taken right after set_mode(MODE_VBLANK)
+                    // when ly has just become 144.
+
+                    // Re-evaluating: The VBLANK mode is set, then LY is incremented during VBLANK.
+                    // The first moment we know a frame is fully drawn is when LY becomes 144.
+                    // At this point, Mode 0 (HBLANK) for line 143 has just finished.
+                    // The PPU then transitions to Mode 1 (VBLANK).
+                    // So, the screenshot should be taken when `self.ly == 144` and `self.cycles == 0` (or very small number)
+                    // signifying the *start* of processing line 144, which is the first VBlank line.
+
+                    // The current code:
+                    // else { // End of a scanline (lines 0-143)
+                    //    self.cycles = 0;
+                    //    self.ly += 1; // ly becomes 0-144
+                    //    self.check_lyc_ly();
+                    //    if self.ly == 144 { // Transition to VBlank
+                    //        self.set_mode(MODE_VBLANK); // Mode becomes 1
+                    //        // SCREENSHOT HERE
+                    //    } else { ... }
+                    // }
+                    // This seems like the correct spot.
+
+                    // match save_framebuffer_to_png(&self.framebuffer, 160, 144, "output.png") {
+                    //     Ok(_) => { /* println!("Framebuffer saved to output.png"); */ }
+                    //     Err(e) => eprintln!("Error saving framebuffer: {}", e),
+                    // }
+                    // Screenshotting is now triggered by main.rs test framework logic
+
+                } else {
+                    // Transition to Mode 2 (OAM Scan) for the next scanline.
+                    self.set_mode(MODE_OAM_SCAN);
+                    // TODO: OAM interrupt for the new line if enabled
+                }
+            }
+        }
+    }
+
+    fn render_scanline(&mut self) {
+        // If LCDC bit 7 is off (LCD disabled), do nothing or fill with white.
+        if (self.lcdc & (1 << 7)) == 0 {
+            for x in 0..160 {
+                let fb_idx = (self.ly as usize * 160 + x) * 3;
+                self.framebuffer[fb_idx..fb_idx + 3].copy_from_slice(&COLOR_WHITE);
+            }
+            return;
+        }
+
+        // If LCDC bit 0 is off (BG/Window display disabled), fill with white.
+        // Note: Some emulators might make this distinction (BG off vs LCD off)
+        // For now, if BG is off, we render white.
+        if (self.lcdc & (1 << 0)) == 0 {
+             for x in 0..160 {
+                let fb_idx = (self.ly as usize * 160 + x) * 3;
+                self.framebuffer[fb_idx..fb_idx + 3].copy_from_slice(&COLOR_WHITE);
+            }
+            return;
+        }
+
+        let tile_map_base_addr = if (self.lcdc & (1 << 3)) == 0 { 0x9800 } else { 0x9C00 };
+        let tile_data_base_addr = if (self.lcdc & (1 << 4)) == 0 { 0x8800 } else { 0x8000 }; // 0x8800 uses signed indexing from 0x9000
+        let signed_tile_addressing = (self.lcdc & (1 << 4)) == 0;
+
+        let current_scanline_y = self.ly; // Y coordinate on the screen (0-143)
+        let scroll_y = self.scy;
+        let scroll_x = self.scx;
+
+        for x_on_screen in 0..160 { // For each pixel on the current scanline (0-159)
+            let map_x = (scroll_x.wrapping_add(x_on_screen)) as u16; // X position in the 256x256 BG map
+            let map_y = (scroll_y.wrapping_add(current_scanline_y)) as u16; // Y position in the 256x256 BG map
+
+            let tile_col_idx = map_x / 8; // Which column of tiles in the map
+            let tile_row_idx = map_y / 8; // Which row of tiles in the map
+
+            // Get tile index from tile map
+            // Each map is 32x32 tiles.
+            let tile_map_offset = tile_row_idx * 32 + tile_col_idx;
+            let tile_index_addr_in_vram = (tile_map_base_addr + tile_map_offset - 0x8000) as usize;
+            let tile_index = self.vram[tile_index_addr_in_vram];
+
+            // Calculate address of the tile's data
+            let tile_data_start_addr_in_vram = if signed_tile_addressing {
+                // Tile data from 0x8800 to 0x97FF. Indices are signed (-128 to 127), relative to 0x9000.
+                // tile_index is u8. Cast to i8 for signed arithmetic.
+                // Effective address = 0x9000 + (tile_index as i8 as i16) * 16
+                // Base for vram array = (0x9000 - 0x8000) + (tile_index as i8 as i16) * 16
+                let base_offset = 0x1000; // 0x9000 - 0x8000
+                (base_offset as i16 + (tile_index as i8 as i16) * 16) as usize
+            } else {
+                // Tile data from 0x8000 to 0x8FFF. Indices are unsigned (0 to 255).
+                // tile_index is u8.
+                // Effective address = 0x8000 + (tile_index as u16) * 16
+                // Base for vram array = (tile_index as u16) * 16
+                (tile_data_base_addr - 0x8000 + (tile_index as u16) * 16) as usize
+            };
+
+            let pixel_y_in_tile = (map_y % 8) as usize; // Which row of pixels in the tile (0-7)
+
+            // Each row of pixels in a tile takes 2 bytes
+            let byte1_vram_addr = tile_data_start_addr_in_vram + pixel_y_in_tile * 2;
+            let byte2_vram_addr = byte1_vram_addr + 1;
+
+            // Ensure addresses are within VRAM bounds (0x0000 to 0x1FFF for the self.vram array)
+            // This check is mostly for the signed addressing which can go "below" 0x8800 if not careful
+            // but since tile_data_start_addr_in_vram is usize, it should be fine.
+            // However, let's be safe. Max address for tile data is 0x97FF for signed, 0x8FFF for unsigned.
+            // Max index in self.vram is 8191 (0x1FFF)
+            if byte2_vram_addr >= 8192 { // VRAM size
+                // This case should ideally not happen with correct logic but indicates an error if it does.
+                // Fill with a debug color like magenta if it happens.
+                let fb_idx = (current_scanline_y as usize * 160 + x_on_screen as usize) * 3;
+                self.framebuffer[fb_idx..fb_idx + 3].copy_from_slice(&[0xFF,0,0xFF]); // Magenta
+                continue;
+            }
+
+            let byte1 = self.vram[byte1_vram_addr];
+            let byte2 = self.vram[byte2_vram_addr];
+
+            // Pixel data is stored from right to left. bit 7 is leftmost pixel, bit 0 is rightmost.
+            let pixel_x_in_tile_bit_pos = 7 - (map_x % 8) as u8;
+
+            let color_bit1 = (byte1 >> pixel_x_in_tile_bit_pos) & 1; // Low bit of color id
+            let color_bit0 = (byte2 >> pixel_x_in_tile_bit_pos) & 1; // High bit of color id
+            let color_num = (color_bit0 << 1) | color_bit1; // gb palette index (0-3)
+
+            // Map through BGP register
+            // color_num 00, 01, 10, 11 corresponds to bits 1-0, 3-2, 5-4, 7-6 of BGP
+            let output_color_num = (self.bgp >> (color_num * 2)) & 0b11;
+            let final_color = DMG_PALETTE[output_color_num as usize];
+
+            let fb_idx = (current_scanline_y as usize * 160 + x_on_screen as usize) * 3;
+            self.framebuffer[fb_idx..fb_idx + 3].copy_from_slice(&final_color);
+        }
+    }
+
+
     pub fn read_byte(&self, addr: u16) -> u8 {
-        println!("PPU read attempt at address: {:#04X}", addr);
-        // Return a dummy value for now
-        0xFF
+        match addr {
+            0x8000..=0x9FFF => { // VRAM
+                // VRAM is readable depending on PPU mode. For now, allow reads.
+                let relative_addr = addr - 0x8000;
+                self.vram[relative_addr as usize]
+            }
+            0xFE00..=0xFE9F => { // OAM
+                // OAM is readable depending on PPU mode. For now, allow reads.
+                let relative_addr = addr - 0xFE00;
+                self.oam[relative_addr as usize]
+            }
+            0xFF40 => self.lcdc,
+            0xFF41 => self.stat | 0x80, // Bit 7 is often reported as high, ensure it is.
+            0xFF42 => self.scy,
+            0xFF43 => self.scx,
+            0xFF44 => self.ly,
+            0xFF45 => self.lyc,
+            0xFF47 => self.bgp,
+            0xFF48 => self.obp0,
+            0xFF49 => self.obp1,
+            0xFF4A => self.wy,
+            0xFF4B => self.wx,
+            _ => {
+                // println!("PPU read from unmapped address: {:#04X}", addr);
+                0xFF // Default for unmapped PPU addresses
+            }
+        }
     }
 
     pub fn write_byte(&mut self, addr: u16, value: u8) {
-        println!("PPU write attempt at address: {:#04X} with value: {:#02X}", addr, value);
-        // Placeholder for PPU write logic
+        // Check if LCD is off; if so, many PPU registers/memory might not be writable
+        // or behave differently. For now, we assume they are writable unless specified.
+        // if (self.lcdc & (1 << 7)) == 0 { /* LCD is off */ }
+
+        match addr {
+            0x8000..=0x9FFF => { // VRAM
+                // VRAM is writable depending on PPU mode. For now, allow writes.
+                let relative_addr = addr - 0x8000;
+                self.vram[relative_addr as usize] = value;
+            }
+            0xFE00..=0xFE9F => { // OAM
+                // OAM is writable depending on PPU mode. For now, allow writes.
+                // TODO: Implement OAM write restrictions (e.g., not writable during Mode 2 and 3).
+                let relative_addr = addr - 0xFE00;
+                self.oam[relative_addr as usize] = value;
+            }
+            0xFF40 => { // LCDC
+                let old_lcd_enabled = (self.lcdc & (1 << 7)) != 0;
+                self.lcdc = value;
+                let new_lcd_enabled = (self.lcdc & (1 << 7)) != 0;
+                if old_lcd_enabled && !new_lcd_enabled {
+                    // LCD turned off: LY resets to 0, PPU clock stops, PPU enters Mode 0.
+                    self.ly = 0;
+                    self.cycles = 0;
+                    self.set_mode(MODE_HBLANK); // Or specific off mode if any
+                    // Framebuffer might be cleared to white.
+                    for i in 0..self.framebuffer.len() { self.framebuffer[i] = 0xFF; }
+                }
+                // If LCD is turned on, PPU starts its sequence.
+                // This is implicitly handled by tick() being called.
+            }
+            0xFF41 => { // STAT
+                // Bits 0-2 (Mode) are read-only from CPU side.
+                // Bit 7 is read-only (always 1).
+                // CPU can write to bits 3-6 (Interrupt enables).
+                self.stat = (value & 0b0111_1000) | (self.stat & 0b1000_0111);
+                // Bit 7 needs to be preserved as 1 (or whatever hardware dictates)
+                self.stat |= 0x80;
+            }
+            0xFF42 => self.scy = value,
+            0xFF43 => self.scx = value,
+            0xFF44 => { /* LY is Read-Only */
+                // Writing to LY on some DMG models resets LY to 0.
+                // For now, treat as read-only (no effect).
+                // self.ly = 0; // If emulating LY reset behavior
+            }
+            0xFF45 => { // LYC
+                self.lyc = value;
+                // LYC=LY check should happen immediately if LYC is written
+                self.check_lyc_ly();
+            }
+            0xFF47 => self.bgp = value, // BGP
+            0xFF48 => self.obp0 = value, // OBP0
+            0xFF49 => self.obp1 = value, // OBP1
+            0xFF4A => self.wy = value,  // WY
+            0xFF4B => self.wx = value,  // WX
+            _ => {
+                // println!("PPU write to unmapped address: {:#04X} with value: {:#02X}", addr, value);
+            }
+        }
+    }
+}
+
+pub fn save_framebuffer_to_png(
+    framebuffer: &[u8],
+    width: u32,
+    height: u32,
+    filepath: &str,
+) -> Result<(), ImageError> {
+    if framebuffer.len() != (width * height * 3) as usize {
+        // This is a simplistic error. A custom error type might be better.
+        return Err(ImageError::Parameter(
+            image::error::ParameterError::from_kind(
+                image::error::ParameterErrorKind::DimensionMismatch,
+            ),
+        ));
+    }
+
+    // Create an RgbImage directly from the flat RGB data.
+    // The `image` crate expects data in row-major order (R, G, B, R, G, B, ...).
+    // Our framebuffer is already in this format.
+    match ImageBuffer::<image::Rgb<u8>, Vec<u8>>::from_raw(width, height, framebuffer.to_vec()) {
+        Some(image_buffer) => {
+            image_buffer.save(filepath) // This returns Result<(), ImageError>
+        }
+        None => {
+            // This case should ideally not be reached if the length check above is correct,
+            // but from_raw can fail for other reasons (e.g. internal allocation issues).
+            Err(ImageError::Parameter(
+                image::error::ParameterError::from_kind(
+                    image::error::ParameterErrorKind::Generic(
+                        "Failed to create image buffer from raw data".to_string(),
+                    ),
+                ),
+            ))
+        }
     }
 }


### PR DESCRIPTION
This commit introduces several key features to the Game Boy emulator:

1.  **PPU Structure and Integration:**
    *   Initialized `Ppu` with VRAM, OAM, framebuffer, and essential registers (LCDC, STAT, SCY, SCX, LY, LYC, BGP, OBP0, OBP1, WY, WX).
    *   Integrated PPU memory map (VRAM, OAM, registers) into the main `Bus`.

2.  **DMG Background Rendering:**
    *   Implemented PPU `tick()` method to manage PPU cycles and modes (OAM Scan, Drawing, HBlank, VBlank).
    *   Added logic to render scanlines for the DMG background layer, respecting LCDC control bits, scroll registers (SCX, SCY), and tile data from VRAM.
    *   Implemented the 4-shade DMG color palette as specified: #000000, #555555, #AAAAAA, #FFFFFF.
    *   PPU state (LY, STAT modes) is updated during ticking.

3.  **Screenshot Functionality:**
    *   Added the `image` crate for PNG image saving.
    *   Implemented `save_framebuffer_to_png` to save the PPU's 160x144 framebuffer to a file.

4.  **PPU Stepping in Main Loop:**
    *   The PPU's `tick()` method is now called from the main emulation loop in `main.rs`, synchronized with CPU M-cycles (assuming 4 PPU T-cycles per M-cycle).

5.  **Basic Test ROM Framework:**
    *   `main.rs` now accepts a ROM path via command-line arguments.
    *   Implemented logic to detect test completion for Blargg's test ROMs by checking memory address 0x6000.
    *   Upon test completion, a screenshot is saved (e.g., `test_output_cpu_instrs.png`).
    *   Removed automatic per-frame screenshotting; screenshots are now triggered by the test framework.

**Limitations & Future Work:**
*   Full CGB color palette implementation is deferred. The current implementation focuses on DMG compatibility.
*   Sprite and Window layer rendering are not yet implemented.
*   I was partially blocked during the "Refine and Test" step, as I encountered some issues that prevented execution and visual verification of test ROMs like `cpu_instrs.gb`. Further testing and debugging of the rendering output will be required.
*   PPU interrupt generation (VBlank, STAT, LYC) is stubbed and needs full implementation.

This work provides the foundational PPU rendering capabilities and a framework for running and visually verifying test ROMs, addressing the core requirements of the issue.