### PR TITLE
feat: Implement manual execution mode with display and logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 image = "0.24"
+minifb = "0.25"


### PR DESCRIPTION
Integrates `minifb` to provide a graphical display window for the emulator.

Key changes:
- Added `minifb` dependency for windowing.
- Modified `main.rs` to create a 160x144 display window.
- The main emulation loop now runs as long as the window is open and updates the display with the PPU's framebuffer content once per frame.
- Includes a helper function to convert the PPU's RGB framebuffer (`Vec<u8>`) to the `u32` format expected by `minifb`.
- Removed Blargg test ROM-specific logic (e.g., `MAX_STEPS`, automatic test status checking, and end-of-test screenshotting).
- Adjusted console logging for general manual operation:
    - Preserved ROM loading messages.
    - Kept periodic serial output and CPU state logging, now tied to a general step counter.
    - The existing `panic!` for undefined opcodes in `cpu.rs` serves as the error logging mechanism for invalid instructions.
- The emulator now starts with `cpu.pc = 0x0100;` for compatibility with ROMs that expect this entry point.

This brings the emulator to a minimum runnable state where you can load a ROM, see graphical output, and get console logs for basic operations and errors.