### PR TITLE
Fix length counter reload on channel trigger

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -593,6 +593,13 @@ impl Apu {
             NR14_ADDR => {
                 let prev_len_enabled = self.channel1.nr14.is_length_enabled();
                 let len_counter_was_non_zero = self.channel1.get_length_counter() > 0;
+                debug!(
+                    "NR14 write: val={:#04X} len_before={} len_enabled_before={} fs_step={}",
+                    value,
+                    self.channel1.get_length_counter(),
+                    prev_len_enabled,
+                    self.frame_sequencer_step
+                );
                 self.channel1.nr14.write(value); // NRx4 is updated
                 let new_len_enabled = self.channel1.nr14.is_length_enabled();
                 // Condition for "APU frame sequencer's next step will not clock the length timer"
@@ -609,6 +616,11 @@ impl Apu {
                     // AND the specific frame sequencer timing condition is met.
                     self.channel1.reload_length_on_enable(self.frame_sequencer_step);
                 }
+                debug!(
+                    "NR14 handled: len_after={} len_enabled_after={}",
+                    self.channel1.get_length_counter(),
+                    new_len_enabled
+                );
             },
             NR21_ADDR => {
                 self.channel2.nr21.write(value);
@@ -633,6 +645,13 @@ impl Apu {
             NR24_ADDR => {
                 let prev_len_enabled = self.channel2.nr24.is_length_enabled();
                 let len_counter_was_non_zero = self.channel2.get_length_counter() > 0;
+                debug!(
+                    "NR24 write: val={:#04X} len_before={} len_enabled_before={} fs_step={}",
+                    value,
+                    self.channel2.get_length_counter(),
+                    prev_len_enabled,
+                    self.frame_sequencer_step
+                );
                 self.channel2.nr24.write(value); // NRx4 is updated
                 let new_len_enabled = self.channel2.nr24.is_length_enabled();
                 let frame_sequencer_condition_met = matches!(self.frame_sequencer_step, 0 | 2 | 4 | 6);
@@ -646,6 +665,11 @@ impl Apu {
                 } else if !prev_len_enabled && new_len_enabled && frame_sequencer_condition_met {
                     self.channel2.reload_length_on_enable(self.frame_sequencer_step);
                 }
+                debug!(
+                    "NR24 handled: len_after={} len_enabled_after={}",
+                    self.channel2.get_length_counter(),
+                    new_len_enabled
+                );
             },
             NR30_ADDR => self.channel3.nr30.write(value),
             NR31_ADDR => {
@@ -666,6 +690,13 @@ impl Apu {
 
                 let prev_len_enabled = self.channel3.nr34.is_length_enabled();
                 let len_counter_was_non_zero = self.channel3.get_length_counter() > 0;
+                debug!(
+                    "NR34 write: val={:#04X} len_before={} len_enabled_before={} fs_step={}",
+                    value,
+                    self.channel3.get_length_counter(),
+                    prev_len_enabled,
+                    self.frame_sequencer_step
+                );
                 self.channel3.nr34.write(value); // NRx4 is updated
                 let new_len_enabled = self.channel3.nr34.is_length_enabled();
                 let frame_sequencer_condition_met = matches!(self.frame_sequencer_step, 0 | 2 | 4 | 6);
@@ -679,6 +710,11 @@ impl Apu {
                 } else if !prev_len_enabled && new_len_enabled && frame_sequencer_condition_met {
                     self.channel3.reload_length_on_enable(self.frame_sequencer_step);
                 }
+                debug!(
+                    "NR34 handled: len_after={} len_enabled_after={}",
+                    self.channel3.get_length_counter(),
+                    new_len_enabled
+                );
             },
             NR41_ADDR => {
                 self.channel4.nr41.write(value);
@@ -703,6 +739,13 @@ impl Apu {
             NR44_ADDR => {
                 let prev_len_enabled = self.channel4.nr44.is_length_enabled();
                 let len_counter_was_non_zero = self.channel4.get_length_counter() > 0;
+                debug!(
+                    "NR44 write: val={:#04X} len_before={} len_enabled_before={} fs_step={}",
+                    value,
+                    self.channel4.get_length_counter(),
+                    prev_len_enabled,
+                    self.frame_sequencer_step
+                );
                 self.channel4.nr44.write(value); // NRx4 is updated
                 let new_len_enabled = self.channel4.nr44.is_length_enabled();
                 let frame_sequencer_condition_met = matches!(self.frame_sequencer_step, 0 | 2 | 4 | 6);
@@ -716,6 +759,11 @@ impl Apu {
                 } else if !prev_len_enabled && new_len_enabled && frame_sequencer_condition_met {
                     self.channel4.reload_length_on_enable(self.frame_sequencer_step);
                 }
+                debug!(
+                    "NR44 handled: len_after={} len_enabled_after={}",
+                    self.channel4.get_length_counter(),
+                    new_len_enabled
+                );
             },
             NR50_ADDR => self.nr50.write(value),
             NR51_ADDR => self.nr51.write(value),

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -598,7 +598,7 @@ impl Apu {
                 // Condition for "APU frame sequencer's next step will not clock the length timer"
                 let frame_sequencer_condition_met = matches!(self.frame_sequencer_step, 0 | 2 | 4 | 6);
 
-                if frame_sequencer_condition_met && !prev_len_enabled && new_len_enabled && len_counter_was_non_zero {
+                if frame_sequencer_condition_met && new_len_enabled && len_counter_was_non_zero {
                     self.channel1.extra_length_clock(trigger_val_in_write);
                 }
 
@@ -637,7 +637,7 @@ impl Apu {
                 let new_len_enabled = self.channel2.nr24.is_length_enabled();
                 let frame_sequencer_condition_met = matches!(self.frame_sequencer_step, 0 | 2 | 4 | 6);
 
-                if frame_sequencer_condition_met && !prev_len_enabled && new_len_enabled && len_counter_was_non_zero {
+                if frame_sequencer_condition_met && new_len_enabled && len_counter_was_non_zero {
                     self.channel2.extra_length_clock(trigger_val_in_write);
                 }
 
@@ -670,7 +670,7 @@ impl Apu {
                 let new_len_enabled = self.channel3.nr34.is_length_enabled();
                 let frame_sequencer_condition_met = matches!(self.frame_sequencer_step, 0 | 2 | 4 | 6);
 
-                if frame_sequencer_condition_met && !prev_len_enabled && new_len_enabled && len_counter_was_non_zero {
+                if frame_sequencer_condition_met && new_len_enabled && len_counter_was_non_zero {
                     self.channel3.extra_length_clock(trigger_val_in_write);
                 }
 
@@ -707,7 +707,7 @@ impl Apu {
                 let new_len_enabled = self.channel4.nr44.is_length_enabled();
                 let frame_sequencer_condition_met = matches!(self.frame_sequencer_step, 0 | 2 | 4 | 6);
 
-                if frame_sequencer_condition_met && !prev_len_enabled && new_len_enabled && len_counter_was_non_zero {
+                if frame_sequencer_condition_met && new_len_enabled && len_counter_was_non_zero {
                     self.channel4.extra_length_clock(trigger_val_in_write);
                 }
 

--- a/src/apu/channel1.rs
+++ b/src/apu/channel1.rs
@@ -51,14 +51,15 @@ impl Channel1 {
         if self.nr12.dac_power() { self.enabled = true; } else { self.enabled = false; return; }
         let length_data = self.nr11.initial_length_timer_val();
         let is_max_length_condition_len = length_data == 0;
-        if self.length_counter == 0 || is_max_length_condition_len {
-            // According to the Pandocs, length data of 0 should be treated as
-            // the maximum length. The extra decrement that may happen on
-            // trigger only occurs when the previous counter was 0.
+        if self.length_counter == 0 {
+            // Treat zero in the length register as the maximum length. The
+            // extra decrement described in the Pandocs only happens when the
+            // counter was previously zero and the next frame sequencer step
+            // won't clock length.
             let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
             let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
             let length_is_enabled_on_trigger = self.nr14.is_length_enabled();
-            if self.length_counter == 0 && next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
                 actual_load_val_len = 63;
             }
             self.length_counter = actual_load_val_len;

--- a/src/apu/channel1.rs
+++ b/src/apu/channel1.rs
@@ -49,15 +49,17 @@ impl Channel1 {
             self.has_been_triggered_since_power_on = true;
         }
         if self.nr12.dac_power() { self.enabled = true; } else { self.enabled = false; return; }
-        let length_data = self.nr11.initial_length_timer_val();
-        let is_max_length_condition_len = length_data == 0;
-        let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
-        let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
-        let length_is_enabled_on_trigger = self.nr14.is_length_enabled();
-        if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
-            actual_load_val_len = 63;
+        if self.length_counter == 0 {
+            let length_data = self.nr11.initial_length_timer_val();
+            let is_max_length_condition_len = length_data == 0;
+            let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
+            let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
+            let length_is_enabled_on_trigger = self.nr14.is_length_enabled();
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+                actual_load_val_len = 63;
+            }
+            self.length_counter = actual_load_val_len;
         }
-        self.length_counter = actual_load_val_len;
         let old_low_two_bits = self.frequency_timer & 0b11;
         let freq_lsb = self.nr13.freq_lo_val() as u16;
         let freq_msb = self.nr14.frequency_msb_val() as u16;

--- a/src/apu/channel1.rs
+++ b/src/apu/channel1.rs
@@ -1,5 +1,6 @@
 // src/apu/channel1.rs
 use super::{Nr10, Nr11, Nr12, Nr13, Nr14};
+use log::debug;
 
 pub struct Channel1 {
     pub nr10: Nr10,
@@ -43,6 +44,12 @@ impl Channel1 {
     }
 
     pub fn trigger(&mut self, current_frame_sequencer_step: u8) {
+        debug!(
+            "CH1 trigger start: len_cnt={} len_enabled={} fs_step={}",
+            self.length_counter,
+            self.nr14.is_length_enabled(),
+            current_frame_sequencer_step
+        );
         self.subtraction_sweep_calculated_since_trigger = false;
         if !self.has_been_triggered_since_power_on {
             self.force_output_zero_for_next_sample = true;
@@ -88,6 +95,7 @@ impl Channel1 {
             let new_freq = self.calculate_sweep_frequency();
             if new_freq > 2047 { self.enabled = false; self.sweep_calculated_overflow_this_step = true; }
         }
+        debug!("CH1 trigger end: len_cnt={}", self.length_counter);
     }
 
     fn calculate_sweep_frequency(&self) -> u16 {
@@ -100,10 +108,16 @@ impl Channel1 {
 
     pub fn extra_length_clock(&mut self, trigger_is_set_in_nrx4: bool) {
         if self.length_counter > 0 {
+            debug!(
+                "CH1 extra_length_clock: before={} trigger={}",
+                self.length_counter,
+                trigger_is_set_in_nrx4
+            );
             self.length_counter -= 1;
             if self.length_counter == 0 && !trigger_is_set_in_nrx4 {
                 self.enabled = false;
             }
+            debug!("CH1 extra_length_clock: after={}", self.length_counter);
         }
     }
 

--- a/src/apu/channel2.rs
+++ b/src/apu/channel2.rs
@@ -1,5 +1,6 @@
 // src/apu/channel2.rs
 use super::{Nr21, Nr22, Nr23, Nr24};
+use log::debug;
 
 pub struct Channel2 {
     pub nr21: Nr21,
@@ -33,6 +34,12 @@ impl Channel2 {
     }
 
     pub fn trigger(&mut self, current_frame_sequencer_step: u8) {
+        debug!(
+            "CH2 trigger start: len_cnt={} len_enabled={} fs_step={}",
+            self.length_counter,
+            self.nr24.is_length_enabled(),
+            current_frame_sequencer_step
+        );
         if !self.has_been_triggered_since_power_on {
             self.force_output_zero_for_next_sample = true;
             self.has_been_triggered_since_power_on = true;
@@ -64,16 +71,23 @@ impl Channel2 {
         }
         self.envelope_period_timer = envelope_timer_load_val;
         self.envelope_running = self.nr22.dac_power() && env_period_raw != 0;
+        debug!("CH2 trigger end: len_cnt={}", self.length_counter);
     }
 
     pub fn get_length_counter(&self) -> u16 { self.length_counter }
 
     pub fn extra_length_clock(&mut self, trigger_is_set_in_nrx4: bool) {
         if self.length_counter > 0 {
+            debug!(
+                "CH2 extra_length_clock: before={} trigger={}",
+                self.length_counter,
+                trigger_is_set_in_nrx4
+            );
             self.length_counter -= 1;
             if self.length_counter == 0 && !trigger_is_set_in_nrx4 {
                 self.enabled = false;
             }
+            debug!("CH2 extra_length_clock: after={}", self.length_counter);
         }
     }
 

--- a/src/apu/channel2.rs
+++ b/src/apu/channel2.rs
@@ -40,11 +40,11 @@ impl Channel2 {
         if self.nr22.dac_power() { self.enabled = true; } else { self.enabled = false; return; }
         let length_data = self.nr21.initial_length_timer_val();
         let is_max_length_condition_len = length_data == 0;
-        if self.length_counter == 0 || is_max_length_condition_len {
+        if self.length_counter == 0 {
             let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
             let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
             let length_is_enabled_on_trigger = self.nr24.is_length_enabled();
-            if self.length_counter == 0 && next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
                 actual_load_val_len = 63;
             }
             self.length_counter = actual_load_val_len;

--- a/src/apu/channel2.rs
+++ b/src/apu/channel2.rs
@@ -38,13 +38,13 @@ impl Channel2 {
             self.has_been_triggered_since_power_on = true;
         }
         if self.nr22.dac_power() { self.enabled = true; } else { self.enabled = false; return; }
-        if self.length_counter == 0 {
-            let length_data = self.nr21.initial_length_timer_val();
-            let is_max_length_condition_len = length_data == 0;
+        let length_data = self.nr21.initial_length_timer_val();
+        let is_max_length_condition_len = length_data == 0;
+        if self.length_counter == 0 || is_max_length_condition_len {
             let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
             let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
             let length_is_enabled_on_trigger = self.nr24.is_length_enabled();
-            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+            if self.length_counter == 0 && next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
                 actual_load_val_len = 63;
             }
             self.length_counter = actual_load_val_len;

--- a/src/apu/channel2.rs
+++ b/src/apu/channel2.rs
@@ -38,15 +38,17 @@ impl Channel2 {
             self.has_been_triggered_since_power_on = true;
         }
         if self.nr22.dac_power() { self.enabled = true; } else { self.enabled = false; return; }
-        let length_data = self.nr21.initial_length_timer_val();
-        let is_max_length_condition_len = length_data == 0;
-        let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
-        let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
-        let length_is_enabled_on_trigger = self.nr24.is_length_enabled();
-        if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
-            actual_load_val_len = 63;
+        if self.length_counter == 0 {
+            let length_data = self.nr21.initial_length_timer_val();
+            let is_max_length_condition_len = length_data == 0;
+            let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
+            let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
+            let length_is_enabled_on_trigger = self.nr24.is_length_enabled();
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+                actual_load_val_len = 63;
+            }
+            self.length_counter = actual_load_val_len;
         }
-        self.length_counter = actual_load_val_len;
         let old_low_two_bits = self.frequency_timer & 0b11;
         let freq_lsb = self.nr23.freq_lo_val() as u16;
         let freq_msb = self.nr24.frequency_msb_val() as u16;

--- a/src/apu/channel3.rs
+++ b/src/apu/channel3.rs
@@ -24,15 +24,17 @@ impl Channel3 {
 
     pub fn trigger(&mut self, _wave_ram_on_trigger: &[u8;16], current_frame_sequencer_step: u8) {
         self.enabled = self.nr30.dac_on();
-        let length_data = self.nr31.sound_length_val();
-        let is_max_length_condition = length_data == 0;
-        let mut actual_load_val = if is_max_length_condition { 256 } else { 256 - (length_data as u16) };
-        let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
-        let length_is_enabled_on_trigger = self.nr34.is_length_enabled();
-        if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition {
-            actual_load_val = 255;
+        if self.length_counter == 0 {
+            let length_data = self.nr31.sound_length_val();
+            let is_max_length_condition = length_data == 0;
+            let mut actual_load_val = if is_max_length_condition { 256 } else { 256 - (length_data as u16) };
+            let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
+            let length_is_enabled_on_trigger = self.nr34.is_length_enabled();
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition {
+                actual_load_val = 255;
+            }
+            self.length_counter = actual_load_val;
         }
-        self.length_counter = actual_load_val;
 
         let freq_lsb = self.nr33.freq_lo_val() as u16;
         let freq_msb = self.nr34.frequency_msb_val() as u16;

--- a/src/apu/channel3.rs
+++ b/src/apu/channel3.rs
@@ -24,13 +24,13 @@ impl Channel3 {
 
     pub fn trigger(&mut self, _wave_ram_on_trigger: &[u8;16], current_frame_sequencer_step: u8) {
         self.enabled = self.nr30.dac_on();
-        if self.length_counter == 0 {
-            let length_data = self.nr31.sound_length_val();
-            let is_max_length_condition = length_data == 0;
+        let length_data = self.nr31.sound_length_val();
+        let is_max_length_condition = length_data == 0;
+        if self.length_counter == 0 || is_max_length_condition {
             let mut actual_load_val = if is_max_length_condition { 256 } else { 256 - (length_data as u16) };
             let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
             let length_is_enabled_on_trigger = self.nr34.is_length_enabled();
-            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition {
+            if self.length_counter == 0 && next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition {
                 actual_load_val = 255;
             }
             self.length_counter = actual_load_val;

--- a/src/apu/channel3.rs
+++ b/src/apu/channel3.rs
@@ -26,11 +26,11 @@ impl Channel3 {
         self.enabled = self.nr30.dac_on();
         let length_data = self.nr31.sound_length_val();
         let is_max_length_condition = length_data == 0;
-        if self.length_counter == 0 || is_max_length_condition {
+        if self.length_counter == 0 {
             let mut actual_load_val = if is_max_length_condition { 256 } else { 256 - (length_data as u16) };
             let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
             let length_is_enabled_on_trigger = self.nr34.is_length_enabled();
-            if self.length_counter == 0 && next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition {
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition {
                 actual_load_val = 255;
             }
             self.length_counter = actual_load_val;

--- a/src/apu/channel3.rs
+++ b/src/apu/channel3.rs
@@ -1,5 +1,6 @@
 // src/apu/channel3.rs
 use super::{Nr30, Nr31, Nr32, Nr33, Nr34};
+use log::debug;
 
 pub struct Channel3 {
     pub nr30: Nr30,
@@ -23,6 +24,12 @@ impl Channel3 {
     }
 
     pub fn trigger(&mut self, _wave_ram_on_trigger: &[u8;16], current_frame_sequencer_step: u8) {
+        debug!(
+            "CH3 trigger start: len_cnt={} len_enabled={} fs_step={}",
+            self.length_counter,
+            self.nr34.is_length_enabled(),
+            current_frame_sequencer_step
+        );
         self.enabled = self.nr30.dac_on();
         let length_data = self.nr31.sound_length_val();
         let is_max_length_condition = length_data == 0;
@@ -42,16 +49,23 @@ impl Channel3 {
         self.frequency_timer = (2048 - period_val) * 2;
         self.sample_index = 0;
         if !self.nr30.dac_on() { self.enabled = false; }
+        debug!("CH3 trigger end: len_cnt={}", self.length_counter);
     }
 
     pub fn get_length_counter(&self) -> u16 { self.length_counter }
 
     pub fn extra_length_clock(&mut self, trigger_is_set_in_nrx4: bool) {
         if self.length_counter > 0 {
+            debug!(
+                "CH3 extra_length_clock: before={} trigger={}",
+                self.length_counter,
+                trigger_is_set_in_nrx4
+            );
             self.length_counter -= 1;
             if self.length_counter == 0 && !trigger_is_set_in_nrx4 {
                 self.enabled = false;
             }
+            debug!("CH3 extra_length_clock: after={}", self.length_counter);
         }
     }
 

--- a/src/apu/channel4.rs
+++ b/src/apu/channel4.rs
@@ -28,13 +28,13 @@ impl Channel4 {
     pub fn trigger(&mut self, current_frame_sequencer_step: u8) {
         if self.nr42.dac_power() { self.enabled = true; }
         else { self.enabled = false; return; }
-        if self.length_counter == 0 {
-            let length_data = self.nr41.initial_length_timer_val();
-            let is_max_length_condition_len = length_data == 0;
+        let length_data = self.nr41.initial_length_timer_val();
+        let is_max_length_condition_len = length_data == 0;
+        if self.length_counter == 0 || is_max_length_condition_len {
             let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
             let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
             let length_is_enabled_on_trigger = self.nr44.is_length_enabled();
-            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+            if self.length_counter == 0 && next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
                 actual_load_val_len = 63;
             }
             self.length_counter = actual_load_val_len;

--- a/src/apu/channel4.rs
+++ b/src/apu/channel4.rs
@@ -30,11 +30,11 @@ impl Channel4 {
         else { self.enabled = false; return; }
         let length_data = self.nr41.initial_length_timer_val();
         let is_max_length_condition_len = length_data == 0;
-        if self.length_counter == 0 || is_max_length_condition_len {
+        if self.length_counter == 0 {
             let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
             let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
             let length_is_enabled_on_trigger = self.nr44.is_length_enabled();
-            if self.length_counter == 0 && next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
                 actual_load_val_len = 63;
             }
             self.length_counter = actual_load_val_len;

--- a/src/apu/channel4.rs
+++ b/src/apu/channel4.rs
@@ -1,5 +1,6 @@
 // src/apu/channel4.rs
 use super::{Nr41, Nr42, Nr43, Nr44};
+use log::debug;
 
 pub struct Channel4 {
     pub nr41: Nr41,
@@ -26,6 +27,12 @@ impl Channel4 {
     }
 
     pub fn trigger(&mut self, current_frame_sequencer_step: u8) {
+        debug!(
+            "CH4 trigger start: len_cnt={} len_enabled={} fs_step={}",
+            self.length_counter,
+            self.nr44.is_length_enabled(),
+            current_frame_sequencer_step
+        );
         if self.nr42.dac_power() { self.enabled = true; }
         else { self.enabled = false; return; }
         let length_data = self.nr41.initial_length_timer_val();
@@ -50,6 +57,7 @@ impl Channel4 {
         self.envelope_running = self.nr42.dac_power() && env_period_raw != 0;
         self.lfsr = 0xFFFF;
         if !self.nr42.dac_power() { self.enabled = false; }
+        debug!("CH4 trigger end: len_cnt={}", self.length_counter);
     }
 
     fn update_frequency_timer(&mut self) {
@@ -63,10 +71,16 @@ impl Channel4 {
 
     pub fn extra_length_clock(&mut self, trigger_is_set_in_nrx4: bool) {
         if self.length_counter > 0 {
+            debug!(
+                "CH4 extra_length_clock: before={} trigger={}",
+                self.length_counter,
+                trigger_is_set_in_nrx4
+            );
             self.length_counter -= 1;
             if self.length_counter == 0 && !trigger_is_set_in_nrx4 {
                 self.enabled = false;
             }
+            debug!("CH4 extra_length_clock: after={}", self.length_counter);
         }
     }
 

--- a/src/apu/channel4.rs
+++ b/src/apu/channel4.rs
@@ -28,15 +28,17 @@ impl Channel4 {
     pub fn trigger(&mut self, current_frame_sequencer_step: u8) {
         if self.nr42.dac_power() { self.enabled = true; }
         else { self.enabled = false; return; }
-        let length_data = self.nr41.initial_length_timer_val();
-        let is_max_length_condition_len = length_data == 0;
-        let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
-        let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
-        let length_is_enabled_on_trigger = self.nr44.is_length_enabled();
-        if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
-            actual_load_val_len = 63;
+        if self.length_counter == 0 {
+            let length_data = self.nr41.initial_length_timer_val();
+            let is_max_length_condition_len = length_data == 0;
+            let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
+            let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
+            let length_is_enabled_on_trigger = self.nr44.is_length_enabled();
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+                actual_load_val_len = 63;
+            }
+            self.length_counter = actual_load_val_len;
         }
-        self.length_counter = actual_load_val_len;
         self.update_frequency_timer();
         self.envelope_volume = self.nr42.initial_volume_val();
         let env_period_raw = self.nr42.envelope_period_val();

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,7 @@ fn parse_args(args_vec: &[String]) -> (bool, Option<u64>, Option<u64>, String, b
 }
 
 fn main() {
+    env_logger::init();
     println!("VibeEmu starting...");
 
     let args_vec: Vec<String> = env::args().collect();


### PR DESCRIPTION
## Summary
- guard length reload logic in each channel's trigger

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68451fd1ae3c8325990d5c84c45e1b68