### PR TITLE
Fix unit tests and warnings

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -733,9 +733,10 @@ mod tests {
         cpu.ld_hl_mem_a();
 
         // To make the test somewhat useful, we can try reading back.
-        // The placeholder APU read should return 0xFF, not what was written.
+        // With the current APU implementation the write is ignored because the
+        // APU is powered off by default, so the register reads as 0.
         let read_back_val = bus.borrow().read_byte(apu_ch1_vol_addr);
-        assert_eq!(read_back_val, 0xFF, "Reading from APU placeholder after write should return dummy value");
+        assert_eq!(read_back_val, 0x00, "Reading NR12 after write while APU is disabled should return 0");
     }
 
     #[test]

--- a/src/bus_tests.rs
+++ b/src/bus_tests.rs
@@ -4,8 +4,6 @@
 #![allow(dead_code)]
 
 use crate::bus::{Bus, SystemMode};
-use crate::ppu::{Ppu, MODE_HBLANK, OAM_SCAN_CYCLES, DRAWING_CYCLES, HBLANK_CYCLES, SCANLINE_CYCLES};
-
 // Helper to create a Bus instance with a simple ROM
 fn setup_bus(rom_data_option: Option<Vec<u8>>, system_mode_override: Option<SystemMode>) -> Bus {
     let mode = system_mode_override.unwrap_or(SystemMode::DMG);

--- a/src/mbc.rs
+++ b/src/mbc.rs
@@ -1962,7 +1962,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_rumble_flag() {
-        let rom = create_rom(64, 0);
+        let _rom = create_rom(64, 0);
         // Cartridge types indicating rumble: 0x1C, 0x1D, 0x1E
         // let mbc_rumble1 = MBC5::new(rom.clone(), 8*1024, 0x1C); // MBC5+RUMBLE+RAM+BATTERY
         // assert!(mbc_rumble1.has_rumble, "has_rumble should be true for type 0x1C");


### PR DESCRIPTION
## Summary
- fix `apu_io_write_placeholder` test to match implemented APU behaviour
- remove unused imports from bus tests
- adjust PPU tests to avoid sprite overlap and update LY=LYC expectations
- suppress unused test variable in mbc tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845b47638a083258d97070ecffe8c15