### PR TITLE
Fix length counter on trigger

### DIFF
--- a/src/apu/channel1.rs
+++ b/src/apu/channel1.rs
@@ -49,15 +49,17 @@ impl Channel1 {
             self.has_been_triggered_since_power_on = true;
         }
         if self.nr12.dac_power() { self.enabled = true; } else { self.enabled = false; return; }
-        let length_data = self.nr11.initial_length_timer_val();
-        let is_max_length_condition_len = length_data == 0;
-        let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
-        let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
-        let length_is_enabled_on_trigger = self.nr14.is_length_enabled();
-        if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
-            actual_load_val_len = 63;
+        if self.length_counter == 0 {
+            let length_data = self.nr11.initial_length_timer_val();
+            let is_max_length_condition_len = length_data == 0;
+            let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
+            let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
+            let length_is_enabled_on_trigger = self.nr14.is_length_enabled();
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+                actual_load_val_len = 63;
+            }
+            self.length_counter = actual_load_val_len;
         }
-        self.length_counter = actual_load_val_len;
         let old_low_two_bits = self.frequency_timer & 0b11;
         let freq_lsb = self.nr13.freq_lo_val() as u16;
         let freq_msb = self.nr14.frequency_msb_val() as u16;

--- a/src/apu/channel2.rs
+++ b/src/apu/channel2.rs
@@ -38,15 +38,17 @@ impl Channel2 {
             self.has_been_triggered_since_power_on = true;
         }
         if self.nr22.dac_power() { self.enabled = true; } else { self.enabled = false; return; }
-        let length_data = self.nr21.initial_length_timer_val();
-        let is_max_length_condition_len = length_data == 0;
-        let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
-        let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
-        let length_is_enabled_on_trigger = self.nr24.is_length_enabled();
-        if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
-            actual_load_val_len = 63;
+        if self.length_counter == 0 {
+            let length_data = self.nr21.initial_length_timer_val();
+            let is_max_length_condition_len = length_data == 0;
+            let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
+            let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
+            let length_is_enabled_on_trigger = self.nr24.is_length_enabled();
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+                actual_load_val_len = 63;
+            }
+            self.length_counter = actual_load_val_len;
         }
-        self.length_counter = actual_load_val_len;
         let old_low_two_bits = self.frequency_timer & 0b11;
         let freq_lsb = self.nr23.freq_lo_val() as u16;
         let freq_msb = self.nr24.frequency_msb_val() as u16;

--- a/src/apu/channel3.rs
+++ b/src/apu/channel3.rs
@@ -24,15 +24,17 @@ impl Channel3 {
 
     pub fn trigger(&mut self, _wave_ram_on_trigger: &[u8;16], current_frame_sequencer_step: u8) {
         self.enabled = self.nr30.dac_on();
-        let length_data = self.nr31.sound_length_val();
-        let is_max_length_condition = length_data == 0;
-        let mut actual_load_val = if is_max_length_condition { 256 } else { 256 - (length_data as u16) };
-        let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
-        let length_is_enabled_on_trigger = self.nr34.is_length_enabled();
-        if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition {
-            actual_load_val = 255;
+        if self.length_counter == 0 {
+            let length_data = self.nr31.sound_length_val();
+            let is_max_length_condition = length_data == 0;
+            let mut actual_load_val = if is_max_length_condition { 256 } else { 256 - (length_data as u16) };
+            let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
+            let length_is_enabled_on_trigger = self.nr34.is_length_enabled();
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition {
+                actual_load_val = 255;
+            }
+            self.length_counter = actual_load_val;
         }
-        self.length_counter = actual_load_val;
 
         let freq_lsb = self.nr33.freq_lo_val() as u16;
         let freq_msb = self.nr34.frequency_msb_val() as u16;

--- a/src/apu/channel4.rs
+++ b/src/apu/channel4.rs
@@ -28,15 +28,17 @@ impl Channel4 {
     pub fn trigger(&mut self, current_frame_sequencer_step: u8) {
         if self.nr42.dac_power() { self.enabled = true; }
         else { self.enabled = false; return; }
-        let length_data = self.nr41.initial_length_timer_val();
-        let is_max_length_condition_len = length_data == 0;
-        let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
-        let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
-        let length_is_enabled_on_trigger = self.nr44.is_length_enabled();
-        if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
-            actual_load_val_len = 63;
+        if self.length_counter == 0 {
+            let length_data = self.nr41.initial_length_timer_val();
+            let is_max_length_condition_len = length_data == 0;
+            let mut actual_load_val_len = if is_max_length_condition_len { 64 } else { 64 - length_data as u16 };
+            let next_fs_step_will_not_clock_length = matches!(current_frame_sequencer_step, 0 | 2 | 4 | 6);
+            let length_is_enabled_on_trigger = self.nr44.is_length_enabled();
+            if next_fs_step_will_not_clock_length && length_is_enabled_on_trigger && is_max_length_condition_len {
+                actual_load_val_len = 63;
+            }
+            self.length_counter = actual_load_val_len;
         }
-        self.length_counter = actual_load_val_len;
         self.update_frequency_timer();
         self.envelope_volume = self.nr42.initial_volume_val();
         let env_period_raw = self.nr42.envelope_period_val();


### PR DESCRIPTION
## Summary
- handle retrigger without reloading length if counter is active
- update square, wave and noise channel trigger behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845bc1065388325a52c611fe36098a9