### PR TITLE
feat(ppu): Implement initial PPU Background Rendering Pipeline

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -268,7 +268,7 @@ impl Bus {
                 for i in 0..160 {
                     // 0xA0 bytes
                     let byte_to_copy = self.read_byte_internal(source_base_address + i as u16);
-                    self.ppu.write_oam(0xFE00 + i as u16, byte_to_copy); // Write to OAM via PPU method
+                    self.ppu.write_oam_dma(0xFE00 + i as u16, byte_to_copy); // Write to OAM via PPU DMA method
                 }
             }
 


### PR DESCRIPTION
This commit introduces several key PPU features, focusing on the background rendering path:

1.  **LCDC Register Control:** I've implemented logic to make PPU operations respect various bits in the LCDC register (0xFF40), including BG display enable, OBJ display enable (stubbed), Window display enable (stubbed), BG tile map select, and BG/Window tile data select.

2.  **Background Pixel Fetching:**
    *   I developed routines to fetch tile numbers and attributes from VRAM for the background layer, considering SCY/SCX scroll registers.
    *   I implemented fetching of actual tile data bytes (plane1, plane2) for the current scanline, respecting CGB tile attributes (VRAM bank, vertical/horizontal flips).
    *   I decoded tile data bytes into 2-bit color indices for each of the 160 pixels on a scanline, storing them in an internal scanline buffer.

3.  **DMG Palette for Background:**
    *   I applied DMG palette transformations using the BGP register (0xFF47) to the 2-bit color indices.
    *   I rendered the resulting RGB colors into the main framebuffer.
    *   I added a temporary grayscale mapping for CGB BG for visual feedback.

4.  **VRAM/OAM Access Restrictions:**
    *   I implemented PPU mode-based access restrictions for VRAM and OAM.
        *   VRAM is now inaccessible by the CPU during Mode 3 (Drawing) when the LCD is on.
        *   OAM is now inaccessible by the CPU during Mode 2 (OAM Scan) and Mode 3 (Drawing) when the LCD is on.
    *   I added a dedicated `write_oam_dma` function to allow the DMA controller to bypass these restrictions for OAM writes, fixing a test failure.

5.  **Build & Test:** All existing tests pass, and the project builds successfully.

6.  **Documentation:** I've updated `PPU_TODO.md` to reflect these changes.

These changes establish a foundational background rendering capability for the PPU.