### PR TITLE
Fix PPU SCX fine scroll and implement basic DMG sprites.

### DIFF
--- a/PPU_TODO.md
+++ b/PPU_TODO.md
@@ -42,14 +42,14 @@ This document outlines the major components, functions, and logic sections that 
 - [ ] **Pixel Fetcher:**
     - [x] **Conceptual BG Tile Info Fetching:** Implemented concrete BG tile data fetching (tile number, attributes, pixel data bytes via `fetch_tile_line_data`).
     - [-] Fetch tile data for Background (done), Window (pending).
-    - [x] Handle SCX/SCY scrolling for BG (as part of `render_scanline_bg`).
+    - [x] Handle SCX/SCY scrolling for BG (as part of render_scanline_bg - Fine X scroll now handled by discarding initial pixels from fetcher/FIFO).
     - [ ] Handle WX/WY for Window positioning.
-    - [ ] Implement dedicated BG/Window pixel fetcher logic (state machine for tile#, data, attributes).
-    - [ ] Implement dedicated Sprite pixel fetcher logic.
+    - [-] Implement dedicated BG/Window pixel fetcher logic (state machine for tile#, data, attributes - BG fetcher improved with fine SCX handling).
+    - [-] Implement dedicated Sprite pixel fetcher logic (Current sprite pipeline loads pre-fetched line data into sprite FIFO; a more traditional cycle-accurate fetcher is future work).
 - [ ] **Pixel FIFO:**
-    - [ ] Implement BG Pixel FIFO.
-    - [ ] Implement Sprite Pixel FIFO.
-    - [ ] Implement FIFO mixing/merging logic for BG and Sprite pixels.
+    - [x] Implement BG Pixel FIFO.
+    - [x] Implement Sprite Pixel FIFO.
+    - [-] Implement FIFO mixing/merging logic for BG and Sprite pixels (Basic DMG mixing implemented; CGB and more complex scenarios pending).
     - [ ] Drive PPU Mode 3 timing based on Pixel Fetcher and FIFO states.
 - [ ] **Sprite (OBJ) Processing:**
     - **OAM Scan (Mode 2):**
@@ -61,7 +61,7 @@ This document outlines the major components, functions, and logic sections that 
     - **Sprite Rendering:**
         - [x] Handle sprite attributes: X-position, tile index, DMG palettes (OBP0/1 via OAM attr), DMG priority (OAM attr), X/Y flip.
         - [x] Implemented 8x8 and 8x16 sprite sizes (controlled by LCDC.2) during OAM scan and fetching.
-        - [x] Correctly mix DMG sprite pixels with BG/Window pixels based on OAM priority attribute and transparency. (CGB BG-to-OAM priority pending full CGB palette/attribute integration in scanline buffer).
+        - [x] Correctly mix DMG sprite pixels with BG/Window pixels based on OAM priority attribute and transparency (DMG mixing now actively handled in Mode 3; CGB BG-to-OAM priority pending full CGB palette/attribute integration in scanline buffer).
 - [ ] **Background (BG) Rendering:**
     - [x] Select correct tile map (LCDC.3). (Used in `render_scanline_bg`)
     - [x] Select correct tile data (LCDC.4). (Used in `render_scanline_bg`)


### PR DESCRIPTION
This commit addresses a rendering bug where graphics appeared bunched on the left side of your screen. This was due to improper handling of SCX register's fine scroll (scx % 8). The PPU's background pixel fetcher now correctly discards initial pixels from the first tile of a scanline based on this fine scroll value.

Additionally, basic support for DMG sprite rendering has been implemented:
- Added a dedicated Sprite Pixel FIFO.
- Implemented logic in PPU Mode 3 to load pre-fetched sprite pixel data (from OAM scan) into the sprite FIFO.
- Introduced pixel mixing logic to combine background and sprite pixels from their respective FIFOs, respecting DMG OBJ-to-BG priority (attribute bit 7) and sprite pixel transparency (color index 0).

The PPU_TODO.md file has been updated to reflect these changes, marking the completion of sprite FIFO implementation and improvements to SCX handling and DMG sprite mixing logic.