### PR TITLE
feat(ppu): Implement window rendering and enhance STAT interrupts

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -604,7 +604,7 @@ impl Bus {
                     0xFF42 => self.ppu.scy = value,
                     0xFF43 => self.ppu.scx = value,
                     // 0xFF44 (LY) is read-only for CPU
-                    0xFF45 => self.ppu.lyc = value,
+                    0xFF45 => self.ppu.update_lyc(value), // LYC: Call PPU method to handle update and STAT check
                     0xFF46 => {
                         // DMA - OAM DMA Start Register
                         self.oam_dma_source_address_upper = value;


### PR DESCRIPTION
This commit introduces several PPU enhancements:

1.  **Window Rendering:**
    *   Full window rendering logic has been implemented in `src/ppu.rs`.
    *   The PPU now correctly uses LCDC bits 0 (master BG/Win enable), 5 (Window display enable), and 6 (Window tile map select).
    *   Window positioning is handled via WX and WY registers.
    *   The pixel fetcher can now switch between fetching background tiles and window tiles, using the `window_internal_line_counter` for the Y-offset and handling fine X-scrolling for the window's start.
    *   CGB tile attributes (VRAM bank, H/V flips) are applied for window tiles.

2.  **STAT Interrupt Logic:**
    *   Reviewed and confirmed existing PPU mode timing logic is largely sound.
    *   Enhanced STAT interrupt triggering: A new `Ppu::update_lyc()` method ensures that CPU writes to the LYC register immediately trigger an LYC=LY coincidence check and potential STAT interrupt.

3.  **PPU_TODO.md:**
    *   Updated `PPU_TODO.md` to reflect the completion status of these features.

**Note:** During development, I encountered a persistent `cargo build` failure ("Internal error occurred when running command") after an initial unrelated compilation fix. This prevented `cargo test` from running. The implemented PPU features are therefore not yet verified by automated tests. This build issue needs separate investigation.