### PR TITLE
Fix: Resolve build warnings and update PPU TODO

### DIFF
--- a/PPU_TODO.md
+++ b/PPU_TODO.md
@@ -41,7 +41,7 @@ This document outlines the major components, functions, and logic sections that 
 *(This section assumes a pipeline similar to hardware or SameBoy's FIFO-based approach. Adapt as necessary.)*
 
 - [ ] **Pixel Fetcher:**
-    - [x] **Conceptual BG Tile Info Fetching:** Implemented concrete BG tile data fetching (tile number, attributes, pixel data bytes via `fetch_tile_line_data`).
+    - [x] **BG Tile Info Fetching:** BG tile data (number, attributes, pixel data) is fetched by the main fetcher logic in `tick_fetcher`.
     - [x] Fetch tile data for Background (done), Window (done - see dedicated logic item). Build issues prevented test verification.
     - [x] Handle SCX/SCY scrolling for BG (as part of render_scanline_bg - Fine X scroll now handled by discarding initial pixels from fetcher/FIFO).
     - [x] Handle WX/WY for Window positioning. <!-- This was under Pixel Fetcher, seems more general to Window -->
@@ -102,9 +102,9 @@ This document outlines the major components, functions, and logic sections that 
     - [x] While DMA logic is in `Bus`, the PPU needs to allow VRAM access during HDMA/GDMA. (PPU VRAM access methods are public)
     - [x] Ensure VRAM access methods (`read_vram`, `write_vram`) are usable by DMA logic.
     - [x] Consider any PPU state that might affect or be affected by HDMA (e.g., HBlank state for HDMA triggers). (PPU sets `just_entered_hblank`, Bus uses it)
-- [x] **CGB Tile Attributes:** (Fetching implemented in `fetch_tile_line_data`)
-    - When fetching BG/Window tiles in CGB mode, read attributes from VRAM bank 1.
-    - Apply attributes: BG-to-OAM priority, vertical/horizontal flip, VRAM bank selection for tile data, palette selection. (Vertical flip and bank selection for tile data used in `fetch_tile_line_data`; H-flip used in `decode_tile_line_to_pixels`; BG palette selection attributes now used in rendering)
+- [x] **CGB Tile Attributes:** BG tile attributes are fetched in `tick_fetcher` and applied during tile data fetching and pixel processing.
+    - When fetching BG/Window tiles in CGB mode, read attributes from VRAM bank 1 (handled in `tick_fetcher`).
+    - Apply attributes: BG-to-OAM priority (pending full implementation), vertical/horizontal flip, VRAM bank selection for tile data, palette selection (all handled in `tick_fetcher` path and `decode_tile_line_to_pixels` or rendering logic).
 
 ## Bus Integration
 - [x] **Register Access:**

--- a/src/apu/channel3.rs
+++ b/src/apu/channel3.rs
@@ -14,7 +14,7 @@ pub struct Channel3 {
     current_sample_buffer: u8,
     wave_form_just_read: bool,
     pulsed: bool,
-    bugged_read_countdown: u8,
+    // bugged_read_countdown: u8, // Removed as per warning: field is never read
 }
 
 impl Channel3 {
@@ -32,7 +32,7 @@ impl Channel3 {
             current_sample_buffer: 0,
             wave_form_just_read: false,
             pulsed: false,
-            bugged_read_countdown: 0,
+            // bugged_read_countdown: 0, // Removed as per warning: field is never read
         }
     }
 
@@ -156,9 +156,9 @@ impl Channel3 {
         self.wave_form_just_read
     }
 
-    pub(super) fn set_wave_form_just_read(&mut self, val: bool) {
-        self.wave_form_just_read = val;
-    }
+    // pub(super) fn set_wave_form_just_read(&mut self, val: bool) { // Removed as per warning: method is never used
+    //     self.wave_form_just_read = val;
+    // }
 
     pub(super) fn get_frequency_timer(&self) -> u16 {
         self.frequency_timer

--- a/src/apu/channel4.rs
+++ b/src/apu/channel4.rs
@@ -19,7 +19,7 @@ pub struct Channel4 {
     lfsr_step_countdown: u32,
     lfsr_shift_amount: u8,
     div_apu_counter: u32,
-    noise_alignment_buffer: u8,
+    // noise_alignment_buffer: u8, // Removed as per warning: field is never read
 
     pub dmg_delayed_start_countdown: u8,
     force_narrow_lfsr_for_glitch: bool,
@@ -43,7 +43,7 @@ impl Channel4 {
             lfsr_step_countdown: 2,
             lfsr_shift_amount: 0,
             div_apu_counter: 0,
-            noise_alignment_buffer: 0,
+            // noise_alignment_buffer: 0, // Removed as per warning: field is never read
             dmg_delayed_start_countdown: 0,
             force_narrow_lfsr_for_glitch: false,
         };

--- a/src/display.rs
+++ b/src/display.rs
@@ -76,12 +76,13 @@ impl Display {
         self.window.as_ref().map_or(false, |w| w.is_key_down(key))
     }
 
-    /// Gets a list of all keys currently pressed.
-    pub fn get_keys_pressed(&self, active_modifiers: minifb::KeyRepeat) -> Option<Vec<Key>> {
-        self.window
-            .as_ref()
-            .map(|w| w.get_keys_pressed(active_modifiers))
-    }
+    // Removed as per warning: method is never used
+    // /// Gets a list of all keys currently pressed.
+    // pub fn get_keys_pressed(&self, active_modifiers: minifb::KeyRepeat) -> Option<Vec<Key>> {
+    //     self.window
+    //         .as_ref()
+    //         .map(|w| w.get_keys_pressed(active_modifiers))
+    // }
 
     /// Checks if a specific mouse button is currently pressed.
     pub fn get_mouse_down(&self, button: MouseButton) -> bool {


### PR DESCRIPTION
This commit addresses several build warnings and updates the PPU_TODO.md file to reflect the current state of the PPU implementation.

Warnings Resolved:
- Removed redundant assignment to `shade` in `ppu.rs`.
- Removed unused field `bugged_read_countdown` from `apu/channel3.rs`.
- Removed unused method `set_wave_form_just_read` from `apu/channel3.rs`.
- Removed unused field `noise_alignment_buffer` from `apu/channel4.rs`.
- Removed unused method `get_keys_pressed` from `display.rs`.
- Removed unused field `oam_index` from `FetchedSpritePixelLine` in `ppu.rs`.
- Removed unused struct `BgTileInfo` and related function `fetch_tile_line_data` from `ppu.rs`.
- Removed unused struct `FetchedTileLineData` from `ppu.rs`.

PPU_TODO.md Updates:
- Updated descriptions for BG tile fetching to reflect the removal of `fetch_tile_line_data` and `BgTileInfo`, clarifying that this logic is handled within `tick_fetcher`.
- Updated CGB Tile Attributes section for clarity.
- Verified and confirmed other completed items in the PPU TODO list.

All build warnings have been resolved, and `cargo build` and `cargo test` now run cleanly.