### PR TITLE
Fix frame limiter and wrap debug logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ opt-level = 0
 [profile.release]
 codegen-units = 1
 lto = false
+
+[features]
+default = []
+debug_logs = []

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -9,6 +9,7 @@ use self::channel1::Channel1;
 use self::channel2::Channel2;
 use self::channel3::Channel3;
 use self::channel4::Channel4;
+#[cfg(feature = "debug_logs")]
 use log::debug;
 
 pub const CPU_CLOCK_HZ: u32 = 4194304;
@@ -924,6 +925,7 @@ impl Apu {
                 }
             }
             _ => {
+                #[cfg(feature = "debug_logs")]
                 debug!("APU read from unhandled/unmapped address: {:#06X}", addr);
                 0xFF
             }


### PR DESCRIPTION
## Summary
- add optional `debug_logs` feature
- gate debug log macro usage behind the new feature
- reduce Bus `RefCell` churn by borrowing once per emulation step
- implement lag counter based frame limiter

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684b8dc3cb488325a165fc2ad618f9f4