### PR TITLE
Implement basic CPU core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ pixels = "0.13"
 cpal = "0.15"
 log = "0.4"
 env_logger = "0.10"
+
+[lib]
+path = "src/lib.rs"

--- a/TODO.md
+++ b/TODO.md
@@ -606,17 +606,17 @@ Implementing a full emulator is complex – breaking it into manageable pieces w
 
 - **CPU Core (basic)** – *Dep: Cartridge (for fetching opcodes from ROM).*
   
-  - Implement CPU registers and the main fetch-decode-execute loop. Start with a limited set of opcodes to get something running (e.g. NOP, JP, basic loads).
-  
-  - Set up reset/initial state: If using boot ROM, load it at 0x0000 and set PC=0x0000. If skipping boot, initialize registers to known defaults (AF=$01B0 on DMG, etc., as per Pan Docs).
-  
-  - For now, ignore interrupts and most peripheral effects; focus on the CPU able to read opcodes and advance PC correctly.
-  
-  - Include a cycle counter in CPU and increment by each instruction’s cycles.
-  
-  - MMU integration: The CPU’s fetch and memory access should call MMU. Implement a provisional MMU that can read from cartridge and an array for RAM. (PPU, APU, etc., can be stubbed: e.g., reads from 0xFF00-FF7F return 0xFF, writes do nothing for now).
-  
-  - Implement enough opcodes to run a simple test. For example, write a test in Rust with a small bytecode that loads values, adds, jumps, etc., and verify CPU produces expected register values. *(Unit test)*.
+  - [x] Implement CPU registers and the main fetch-decode-execute loop. Start with a limited set of opcodes to get something running (e.g. NOP, JP, basic loads).
+
+  - [x] Set up reset/initial state: If using boot ROM, load it at 0x0000 and set PC=0x0000. If skipping boot, initialize registers to known defaults (AF=$01B0 on DMG, etc., as per Pan Docs).
+
+  - [x] For now, ignore interrupts and most peripheral effects; focus on the CPU able to read opcodes and advance PC correctly.
+
+  - [x] Include a cycle counter in CPU and increment by each instruction’s cycles.
+
+  - [x] MMU integration: The CPU’s fetch and memory access should call MMU. Implement a provisional MMU that can read from cartridge and an array for RAM. (PPU, APU, etc., can be stubbed: e.g., reads from 0xFF00-FF7F return 0xFF, writes do nothing for now).
+
+  - [x] Implement enough opcodes to run a simple test. For example, write a test in Rust with a small bytecode that loads values, adds, jumps, etc., and verify CPU produces expected register values. *(Unit test)*.
   
   - Gradually implement all opcodes. Use a reference (like Pan Docs or Game Boy manual) to ensure each sets flags correctly. For CB-prefixed opcodes (bit operations, shifts, etc.), implement those too.
   

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -14,18 +14,119 @@ pub struct Cpu {
 
 impl Cpu {
     pub fn new() -> Self {
+        // Default post-boot state for DMG as documented in Pan Docs. PC is
+        // normally 0x0100 after the boot ROM, but tests may override this.
         Self {
-            a: 0,
-            f: 0,
-            b: 0,
-            c: 0,
-            d: 0,
-            e: 0,
-            h: 0,
-            l: 0,
-            pc: 0,
-            sp: 0,
+            a: 0x01,
+            f: 0xB0,
+            b: 0x00,
+            c: 0x13,
+            d: 0x00,
+            e: 0xD8,
+            h: 0x01,
+            l: 0x4D,
+            pc: 0x0100,
+            sp: 0xFFFE,
             cycles: 0,
+        }
+    }
+
+    fn get_bc(&self) -> u16 {
+        ((self.b as u16) << 8) | self.c as u16
+    }
+
+    fn set_bc(&mut self, val: u16) {
+        self.b = (val >> 8) as u8;
+        self.c = val as u8;
+    }
+
+    fn get_de(&self) -> u16 {
+        ((self.d as u16) << 8) | self.e as u16
+    }
+
+    fn set_de(&mut self, val: u16) {
+        self.d = (val >> 8) as u8;
+        self.e = val as u8;
+    }
+
+    fn get_hl(&self) -> u16 {
+        ((self.h as u16) << 8) | self.l as u16
+    }
+
+    fn set_hl(&mut self, val: u16) {
+        self.h = (val >> 8) as u8;
+        self.l = val as u8;
+    }
+
+    pub fn step(&mut self, mmu: &mut crate::mmu::Mmu) {
+        let opcode = mmu.read_byte(self.pc);
+        self.pc = self.pc.wrapping_add(1);
+
+        match opcode {
+            0x00 => {
+                // NOP
+                self.cycles += 4;
+            }
+            0x06 => {
+                let val = mmu.read_byte(self.pc);
+                self.pc = self.pc.wrapping_add(1);
+                self.b = val;
+                self.cycles += 8;
+            }
+            0x0E => {
+                let val = mmu.read_byte(self.pc);
+                self.pc = self.pc.wrapping_add(1);
+                self.c = val;
+                self.cycles += 8;
+            }
+            0x16 => {
+                let val = mmu.read_byte(self.pc);
+                self.pc = self.pc.wrapping_add(1);
+                self.d = val;
+                self.cycles += 8;
+            }
+            0x1E => {
+                let val = mmu.read_byte(self.pc);
+                self.pc = self.pc.wrapping_add(1);
+                self.e = val;
+                self.cycles += 8;
+            }
+            0x26 => {
+                let val = mmu.read_byte(self.pc);
+                self.pc = self.pc.wrapping_add(1);
+                self.h = val;
+                self.cycles += 8;
+            }
+            0x2E => {
+                let val = mmu.read_byte(self.pc);
+                self.pc = self.pc.wrapping_add(1);
+                self.l = val;
+                self.cycles += 8;
+            }
+            0x3E => {
+                let val = mmu.read_byte(self.pc);
+                self.pc = self.pc.wrapping_add(1);
+                self.a = val;
+                self.cycles += 8;
+            }
+            0x77 => {
+                let addr = self.get_hl();
+                mmu.write_byte(addr, self.a);
+                self.cycles += 8;
+            }
+            0xAF => {
+                self.a ^= self.a;
+                // XOR A resets NF, HF, CF and sets Z
+                self.f = 0x80;
+                self.cycles += 4;
+            }
+            0xC3 => {
+                let lo = mmu.read_byte(self.pc) as u16;
+                let hi = mmu.read_byte(self.pc.wrapping_add(1)) as u16;
+                self.pc = (hi << 8) | lo;
+                self.cycles += 16;
+            }
+            _ => panic!("unhandled opcode {:02X}", opcode),
         }
     }
 }

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -1,4 +1,4 @@
-use crate::{cpu::Cpu, mmu::Mmu, ppu::Ppu, apu::Apu, cartridge::Cartridge, timer::Timer};
+use crate::{apu::Apu, cpu::Cpu, mmu::Mmu, ppu::Ppu, timer::Timer};
 
 pub struct GameBoy {
     pub cpu: Cpu,
@@ -6,7 +6,6 @@ pub struct GameBoy {
     pub ppu: Ppu,
     pub apu: Apu,
     pub timer: Timer,
-    pub cart: Option<Cartridge>,
 }
 
 impl GameBoy {
@@ -17,7 +16,6 @@ impl GameBoy {
             ppu: Ppu::new(),
             apu: Apu::new(),
             timer: Timer::new(),
-            cart: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod apu;
+pub mod cartridge;
+pub mod cpu;
+pub mod gameboy;
+pub mod mmu;
+pub mod ppu;
+pub mod timer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-mod cpu;
-mod mmu;
-mod ppu;
 mod apu;
 mod cartridge;
-mod timer;
+mod cpu;
 mod gameboy;
+mod mmu;
+mod ppu;
+mod timer;
 
 use clap::Parser;
 use log::info;
@@ -34,7 +34,7 @@ fn main() {
     if let Some(path) = args.rom {
         match std::fs::read(path) {
             Ok(data) => {
-                gb.cart = Some(cartridge::Cartridge::load(data));
+                gb.mmu.load_cart(cartridge::Cartridge::load(data));
             }
             Err(e) => {
                 eprintln!("Failed to load ROM: {e}");
@@ -47,5 +47,8 @@ fn main() {
     }
 
     // TODO: main emulation loop will go here
-    println!("Emulator initialized in {} mode", if args.dmg { "DMG" } else { "CGB" });
+    println!(
+        "Emulator initialized in {} mode",
+        if args.dmg { "DMG" } else { "CGB" }
+    );
 }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -1,14 +1,31 @@
+use crate::cartridge::Cartridge;
+
 pub struct Mmu {
     pub wram: [u8; 0x2000],
+    pub cart: Option<Cartridge>,
 }
 
 impl Mmu {
     pub fn new() -> Self {
-        Self { wram: [0; 0x2000] }
+        Self {
+            wram: [0; 0x2000],
+            cart: None,
+        }
+    }
+
+    pub fn load_cart(&mut self, cart: Cartridge) {
+        self.cart = Some(cart);
     }
 
     pub fn read_byte(&self, addr: u16) -> u8 {
         match addr {
+            0x0000..=0x7FFF => {
+                if let Some(cart) = &self.cart {
+                    cart.rom.get(addr as usize).copied().unwrap_or(0xFF)
+                } else {
+                    0xFF
+                }
+            }
             0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize],
             _ => 0xFF,
         }
@@ -17,7 +34,7 @@ impl Mmu {
     pub fn write_byte(&mut self, addr: u16, val: u8) {
         match addr {
             0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize] = val,
-            _ => {},
+            _ => {}
         }
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -7,6 +7,11 @@ pub struct Timer {
 
 impl Timer {
     pub fn new() -> Self {
-        Self { div: 0, tima: 0, tma: 0, tac: 0 }
+        Self {
+            div: 0,
+            tima: 0,
+            tma: 0,
+            tac: 0,
+        }
     }
 }

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -1,0 +1,34 @@
+use vibeEmu::{cartridge::Cartridge, cpu::Cpu, mmu::Mmu};
+
+#[test]
+fn simple_program() {
+    // Program that loads values and stores to RAM then jumps
+    let program = vec![
+        0x06, 0x12, // LD B,0x12
+        0x0E, 0x34, // LD C,0x34
+        0x26, 0xC0, // LD H,0xC0
+        0x2E, 0x00, // LD L,0x00
+        0x3E, 0x56, // LD A,0x56
+        0x77, // LD (HL),A
+        0xAF, // XOR A
+        0xC3, 0x10, 0x00, // JP 0x0010
+        0x00, // padding
+        0x00, // 0x0010: NOP
+    ];
+
+    let mut cpu = Cpu::new();
+    cpu.pc = 0; // start executing at 0
+    let mut mmu = Mmu::new();
+    mmu.load_cart(Cartridge { rom: program });
+
+    for _ in 0..8 {
+        cpu.step(&mut mmu);
+    }
+
+    assert_eq!(cpu.b, 0x12);
+    assert_eq!(cpu.c, 0x34);
+    assert_eq!(cpu.a, 0x00); // XOR A cleared A
+    assert_eq!(mmu.read_byte(0xC000), 0x56);
+    assert_eq!(cpu.pc, 0x0010);
+    assert_eq!(cpu.cycles, 68);
+}


### PR DESCRIPTION
## Summary
- implement CPU registers and fetch/execute loop with a handful of opcodes
- integrate a minimal MMU that can read from cartridge ROM
- add a simple unit test verifying CPU execution
- expose internal modules via a new library crate
- mark several CPU tasks as complete in TODO

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684b9f0951f48325a6dba3e1820a8cb6