### PR TITLE
Run blargg individual tests & CPU fixes

### DIFF
--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -2,6 +2,7 @@ use crate::cartridge::Cartridge;
 
 pub struct Mmu {
     pub wram: [u8; 0x2000],
+    pub hram: [u8; 0x80],
     pub cart: Option<Cartridge>,
     pub if_reg: u8,
     pub ie_reg: u8,
@@ -14,6 +15,7 @@ impl Mmu {
     pub fn new() -> Self {
         Self {
             wram: [0; 0x2000],
+            hram: [0; 0x80],
             cart: None,
             if_reg: 0,
             ie_reg: 0,
@@ -37,6 +39,7 @@ impl Mmu {
                 }
             }
             0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize],
+            0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
             0xFF01 => self.sb,
             0xFF02 => self.sc,
             0xFF0F => self.if_reg,
@@ -48,6 +51,7 @@ impl Mmu {
     pub fn write_byte(&mut self, addr: u16, val: u8) {
         match addr {
             0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize] = val,
+            0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize] = val,
             0xFF01 => self.sb = val,
             0xFF02 => {
                 self.sc = val;


### PR DESCRIPTION
## Summary
- execute each test ROM in `cpu_instrs/individual` instead of the monolithic test
- add HRAM support in the MMU
- implement several missing CPU instructions and fix flag behavior

## Testing
- `cargo clippy -- -D warnings`
- `cargo test` *(fails: cpu_instrs_individual - Timer doesn't work)*

------
https://chatgpt.com/codex/tasks/task_e_684c690ddd688325bcfacf8a6093fe56