### PR TITLE
Implement cartridge RAM mapping in MMU

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -630,7 +630,7 @@ Implementing a full emulator is complex – breaking it into manageable pieces w
   
   - Flesh out the MMU to cover all regions:  
     
-    * Map 0x0000-0x7FFF and 0xA000-BFFF through Cartridge module (done).  
+    * [x] Map 0x0000-0x7FFF and 0xA000-BFFF through Cartridge module.
     * [x] Allocate 8KB for WRAM, and if CGB mode, 8 banks (bank 1-7) of an additional 4KB each (total 32KB, though one bank is fixed at 0).
     * [x] Map WRAM bank 0 at C000-CFFF, switchable WRAM bank at D000-DFFF (default to bank 1). Implement writes to FF70 (SVBK) to change the bank (on DMG, ignore it).
     * [x] VRAM: allocate 8KB (DMG) or 2×8KB (CGB). Map bank 0 (or selected bank) at 8000-9FFF. Implement FF4F register to switch VRAM bank on CGB.

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -1,9 +1,23 @@
 pub struct Cartridge {
     pub rom: Vec<u8>,
+    pub ram: Vec<u8>,
 }
 
 impl Cartridge {
     pub fn load(data: Vec<u8>) -> Self {
-        Self { rom: data }
+        Self {
+            rom: data,
+            ram: vec![0; 0x2000],
+        }
+    }
+
+    pub fn read_ram(&self, addr: u16) -> u8 {
+        self.ram.get(addr as usize).copied().unwrap_or(0xFF)
+    }
+
+    pub fn write_ram(&mut self, addr: u16, val: u8) {
+        if let Some(b) = self.ram.get_mut(addr as usize) {
+            *b = val;
+        }
     }
 }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -70,7 +70,11 @@ impl Mmu {
                 .and_then(|c| c.rom.get(addr as usize).copied())
                 .unwrap_or(0xFF),
             0x8000..=0x9FFF => self.vram[self.vram_bank][(addr - 0x8000) as usize],
-            0xA000..=0xBFFF => 0xFF,
+            0xA000..=0xBFFF => self
+                .cart
+                .as_ref()
+                .map(|c| c.read_ram(addr - 0xA000))
+                .unwrap_or(0xFF),
             0xC000..=0xCFFF => self.wram[0][(addr - 0xC000) as usize],
             0xD000..=0xDFFF => self.wram[self.wram_bank][(addr - 0xD000) as usize],
             0xE000..=0xEFFF => self.wram[0][(addr - 0xE000) as usize],
@@ -97,7 +101,11 @@ impl Mmu {
             0x8000..=0x9FFF => {
                 self.vram[self.vram_bank][(addr - 0x8000) as usize] = val;
             }
-            0xA000..=0xBFFF => {}
+            0xA000..=0xBFFF => {
+                if let Some(cart) = self.cart.as_mut() {
+                    cart.write_ram(addr - 0xA000, val);
+                }
+            }
             0xC000..=0xCFFF => self.wram[0][(addr - 0xC000) as usize] = val,
             0xD000..=0xDFFF => self.wram[self.wram_bank][(addr - 0xD000) as usize] = val,
             0xE000..=0xEFFF => self.wram[0][(addr - 0xE000) as usize] = val,

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -19,7 +19,7 @@ fn simple_program() {
     let mut cpu = Cpu::new();
     cpu.pc = 0; // start executing at 0
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge { rom: program });
+    mmu.load_cart(Cartridge::load(program));
 
     for _ in 0..8 {
         cpu.step(&mut mmu);
@@ -42,7 +42,7 @@ fn interrupt_handling() {
     cpu.sp = 0xC100;
     cpu.ime = true;
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge { rom: program });
+    mmu.load_cart(Cartridge::load(program));
     mmu.if_reg = 0x01;
     mmu.ie_reg = 0x01;
 
@@ -65,9 +65,7 @@ fn jr_nz_cycles() {
     cpu.pc = 0;
     cpu.f = 0x00; // Z flag cleared
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge {
-        rom: program.clone(),
-    });
+    mmu.load_cart(Cartridge::load(program.clone()));
     cpu.step(&mut mmu);
 
     assert_eq!(cpu.pc, 3);
@@ -77,7 +75,7 @@ fn jr_nz_cycles() {
     cpu.pc = 0;
     cpu.f = 0x80; // Z flag set
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge { rom: program });
+    mmu.load_cart(Cartridge::load(program));
     cpu.step(&mut mmu);
 
     assert_eq!(cpu.pc, 2);
@@ -91,7 +89,7 @@ fn ei_delay() {
     let mut cpu = Cpu::new();
     cpu.pc = 0;
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge { rom: program });
+    mmu.load_cart(Cartridge::load(program));
 
     cpu.step(&mut mmu); // EI
     assert!(!cpu.ime);
@@ -122,7 +120,7 @@ fn ld_rr_instructions() {
     let mut cpu = Cpu::new();
     cpu.pc = 0;
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge { rom: program });
+    mmu.load_cart(Cartridge::load(program));
 
     for _ in 0..15 {
         cpu.step(&mut mmu);
@@ -147,7 +145,7 @@ fn alu_immediate_ops() {
     let mut cpu = Cpu::new();
     cpu.pc = 0;
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge { rom: program });
+    mmu.load_cart(Cartridge::load(program));
 
     for _ in 0..4 {
         cpu.step(&mut mmu);
@@ -177,7 +175,7 @@ fn alu_register_ops() {
     let mut cpu = Cpu::new();
     cpu.pc = 0;
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge { rom: program });
+    mmu.load_cart(Cartridge::load(program));
 
     for _ in 0..12 {
         cpu.step(&mut mmu);

--- a/tests/mmu.rs
+++ b/tests/mmu.rs
@@ -42,8 +42,24 @@ fn boot_rom_disable() {
     mmu.load_boot_rom(vec![0xAA; 0x100]);
     mmu.load_cart(Cartridge {
         rom: vec![0xBB; 0x200],
+        ram: vec![0; 0x2000],
     });
     assert_eq!(mmu.read_byte(0x00), 0xAA);
     mmu.write_byte(0xFF50, 1);
     assert_eq!(mmu.read_byte(0x00), 0xBB);
+}
+
+#[test]
+fn cartridge_ram_access() {
+    let mut mmu = Mmu::new();
+    mmu.load_cart(Cartridge {
+        rom: vec![0; 0x200],
+        ram: vec![0; 0x2000],
+    });
+
+    mmu.write_byte(0xA000, 0x55);
+    assert_eq!(mmu.read_byte(0xA000), 0x55);
+
+    mmu.write_byte(0xBFFF, 0xAA);
+    assert_eq!(mmu.read_byte(0xBFFF), 0xAA);
 }


### PR DESCRIPTION
## Summary
- support cartridge RAM by extending `Cartridge` with a RAM vector
- map 0xA000–0xBFFF through cartridge RAM in `Mmu`
- update unit tests for new cartridge RAM behavior and add new test
- mark TODO task as complete

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`
- `cargo test --release --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684c796d8b0c832585e0de6cafc4b19a