### PR TITLE
Implement cartridge header parsing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -587,22 +587,22 @@ Implementing a full emulator is complex – breaking it into manageable pieces w
 
 - **Cartridge Loading** – *Dep: Project setup.*
   
-  - Write a function to load a ROM file into memory (Vec<u8>).
+    - [x] Write a function to load a ROM file into memory (Vec<u8>).
   
-  - Parse the cartridge header to determine MBC type, RAM size, and whether the game supports CGB mode (if CGB and the user’s emulator is in “CGB capable” mode, we’ll emulate in color mode, otherwise DMG mode).
+    - [x] Parse the cartridge header to determine MBC type, RAM size, and whether the game supports CGB mode (if CGB and the user’s emulator is in “CGB capable” mode, we’ll emulate in color mode, otherwise DMG mode).
   
-  - Instantiate the appropriate MBC state (for now, implement **No MBC** (ROM only), **MBC1**, **MBC3**, **MBC5** as these cover most games[github.com](https://github.com/mvdnes/rboy#:~:text=%2A%20MMU%20%2A%20MBC,Printing). Others can be stubbed or added later).
+    - [x] Instantiate the appropriate MBC state (for now, implement **No MBC** (ROM only), **MBC1**, **MBC3**, **MBC5** as these cover most games[github.com](https://github.com/mvdnes/rboy#:~:text=%2A%20MMU%20%2A%20MBC,Printing). Others can be stubbed or added later).
   
-  - Initialize cartridge RAM (Vec<u8> of correct size, filled with 0xFF or 0x00). If a battery save file exists for this ROM (determine filename by ROM name), load it into RAM.
+    - [x] Initialize cartridge RAM (Vec<u8> of correct size, filled with 0xFF or 0x00). If a battery save file exists for this ROM (determine filename by ROM name), load it into RAM.
   
-  - Implement basic `read(addr)` and `write(addr, val)` for ROM/RAM:  
+    - [x] Implement basic `read(addr)` and `write(addr, val)` for ROM/RAM:  
     
     * For No MBC: reading 0x0000-0x7FFF just returns from ROM (no banking), writing 0xA000-BFFF writes to RAM if present.  
     * For MBC1: support bank switching (5-bit ROM bank number, 2-bit RAM bank or upper ROM bits, mode select), and RAM enable.  
     * For MBC3: support 7-bit ROM bank, 4 8KB RAM banks, RTC registers mapping (just stub the RTC read/write logic initially), RAM enable.  
     * For MBC5: support 9-bit ROM bank, up to 16 RAM banks, RAM enable, possibly rumble enable bit (can ignore actual rumble feedback for now).
   
-  - Test: print out some cartridge info (title, MBC type) to ensure parsing is correct.
+    - [x] Test: print out some cartridge info (title, MBC type) to ensure parsing is correct.
 
 - **CPU Core (basic)** – *Dep: Cartridge (for fetching opcodes from ROM).*
   

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -1,23 +1,346 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MbcType {
+    NoMbc,
+    Mbc1,
+    Mbc3,
+    Mbc5,
+    Unknown(u8),
+}
+
+#[derive(Debug)]
 pub struct Cartridge {
     pub rom: Vec<u8>,
     pub ram: Vec<u8>,
+    pub mbc: MbcType,
+    pub cgb: bool,
+    pub title: String,
+    cart_type: u8,
+    mbc_state: MbcState,
+}
+
+#[derive(Debug)]
+enum MbcState {
+    NoMbc,
+    Mbc1 {
+        rom_bank: u8,
+        ram_bank: u8,
+        mode: u8,
+        ram_enable: bool,
+    },
+    Mbc3 {
+        rom_bank: u8,
+        ram_bank: u8,
+        ram_enable: bool,
+    },
+    Mbc5 {
+        rom_bank: u16,
+        ram_bank: u8,
+        ram_enable: bool,
+    },
+    Unknown,
 }
 
 impl Cartridge {
+    pub fn from_bytes_with_ram(data: Vec<u8>, ram_size: usize) -> Self {
+        let mut c = Self::load(data);
+        c.ram = vec![0; ram_size];
+        c
+    }
+
+    pub fn from_file<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let data = fs::read(&path)?;
+        let mut cart = Self::load(data);
+
+        if cart.has_battery() {
+            let mut save = PathBuf::from(path.as_ref());
+            save.set_extension("sav");
+            if let Ok(bytes) = fs::read(save) {
+                for (d, s) in cart.ram.iter_mut().zip(bytes.iter()) {
+                    *d = *s;
+                }
+            }
+        }
+
+        println!("Loaded ROM: {} (MBC: {:?})", cart.title, cart.mbc);
+        Ok(cart)
+    }
+
     pub fn load(data: Vec<u8>) -> Self {
+        let header = Header::parse(&data);
+        let ram_size = header.ram_size();
+
+        let cart_type = header.cart_type();
+        let mbc = header.mbc_type();
+        let cgb = header.cgb_supported();
+        let title = header.title();
+
+        let mbc_state = match mbc {
+            MbcType::NoMbc => MbcState::NoMbc,
+            MbcType::Mbc1 => MbcState::Mbc1 {
+                rom_bank: 1,
+                ram_bank: 0,
+                mode: 0,
+                ram_enable: false,
+            },
+            MbcType::Mbc3 => MbcState::Mbc3 {
+                rom_bank: 1,
+                ram_bank: 0,
+                ram_enable: false,
+            },
+            MbcType::Mbc5 => MbcState::Mbc5 {
+                rom_bank: 1,
+                ram_bank: 0,
+                ram_enable: false,
+            },
+            MbcType::Unknown(_) => MbcState::Unknown,
+        };
+
         Self {
             rom: data,
-            ram: vec![0; 0x2000],
+            ram: vec![0; ram_size],
+            mbc,
+            cgb,
+            title,
+            cart_type,
+            mbc_state,
         }
     }
 
-    pub fn read_ram(&self, addr: u16) -> u8 {
-        self.ram.get(addr as usize).copied().unwrap_or(0xFF)
+    pub fn read(&self, addr: u16) -> u8 {
+        match (&self.mbc_state, addr) {
+            (MbcState::NoMbc, 0x0000..=0x7FFF) => {
+                self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+            }
+            (MbcState::Mbc1 { rom_bank, mode, .. }, 0x0000..=0x3FFF) => {
+                let bank = if *mode == 0 {
+                    0
+                } else {
+                    *rom_bank as usize & 0x60
+                };
+                let offset = bank * 0x4000 + addr as usize;
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            (MbcState::Mbc1 { rom_bank, mode, .. }, 0x4000..=0x7FFF) => {
+                let bank_hi = if *mode == 0 {
+                    *rom_bank as usize & 0x7F
+                } else {
+                    *rom_bank as usize
+                };
+                let bank = if bank_hi == 0 { 1 } else { bank_hi };
+                let offset = bank * 0x4000 + (addr as usize - 0x4000);
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            (MbcState::Mbc3 { .. }, 0x0000..=0x3FFF) => {
+                self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+            }
+            (MbcState::Mbc3 { rom_bank, .. }, 0x4000..=0x7FFF) => {
+                let bank = if *rom_bank == 0 { 1 } else { *rom_bank } as usize;
+                let offset = bank * 0x4000 + (addr as usize - 0x4000);
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            (MbcState::Mbc5 { .. }, 0x0000..=0x3FFF) => {
+                self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+            }
+            (MbcState::Mbc5 { rom_bank, .. }, 0x4000..=0x7FFF) => {
+                let offset = (*rom_bank as usize) * 0x4000 + (addr as usize - 0x4000);
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            (_, 0xA000..=0xBFFF) => {
+                let idx = self.ram_index(addr);
+                self.ram.get(idx).copied().unwrap_or(0xFF)
+            }
+            _ => 0xFF,
+        }
     }
 
-    pub fn write_ram(&mut self, addr: u16, val: u8) {
-        if let Some(b) = self.ram.get_mut(addr as usize) {
-            *b = val;
+    pub fn write(&mut self, addr: u16, val: u8) {
+        match (&mut self.mbc_state, addr) {
+            (MbcState::NoMbc, 0xA000..=0xBFFF) => {
+                let idx = addr as usize - 0xA000;
+                if let Some(b) = self.ram.get_mut(idx) {
+                    *b = val;
+                }
+            }
+            (MbcState::Mbc1 { ram_enable, .. }, 0x0000..=0x1FFF) => {
+                *ram_enable = val & 0x0F == 0x0A;
+            }
+            (MbcState::Mbc1 { rom_bank, .. }, 0x2000..=0x3FFF) => {
+                *rom_bank = val & 0x1F;
+                if *rom_bank == 0 {
+                    *rom_bank = 1;
+                }
+            }
+            (MbcState::Mbc1 { ram_bank, .. }, 0x4000..=0x5FFF) => {
+                *ram_bank = val & 0x03;
+            }
+            (MbcState::Mbc1 { mode, .. }, 0x6000..=0x7FFF) => {
+                *mode = val & 0x01;
+            }
+            (
+                MbcState::Mbc1 {
+                    ram_enable,
+                    ram_bank,
+                    mode,
+                    ..
+                },
+                0xA000..=0xBFFF,
+            ) => {
+                if *ram_enable {
+                    let idx = if *mode == 0 {
+                        addr as usize - 0xA000
+                    } else {
+                        (*ram_bank as usize) * 0x2000 + addr as usize - 0xA000
+                    };
+                    if let Some(b) = self.ram.get_mut(idx) {
+                        *b = val;
+                    }
+                }
+            }
+            (MbcState::Mbc3 { ram_enable, .. }, 0x0000..=0x1FFF) => {
+                *ram_enable = val & 0x0F == 0x0A;
+            }
+            (MbcState::Mbc3 { rom_bank, .. }, 0x2000..=0x3FFF) => {
+                *rom_bank = val & 0x7F;
+                if *rom_bank == 0 {
+                    *rom_bank = 1;
+                }
+            }
+            (MbcState::Mbc3 { ram_bank, .. }, 0x4000..=0x5FFF) => {
+                *ram_bank = val & 0x03;
+            }
+            (
+                MbcState::Mbc3 {
+                    ram_enable,
+                    ram_bank,
+                    ..
+                },
+                0xA000..=0xBFFF,
+            ) => {
+                if *ram_enable {
+                    let idx = (*ram_bank as usize) * 0x2000 + addr as usize - 0xA000;
+                    if let Some(b) = self.ram.get_mut(idx) {
+                        *b = val;
+                    }
+                }
+            }
+            (MbcState::Mbc5 { ram_enable, .. }, 0x0000..=0x1FFF) => {
+                *ram_enable = val & 0x0F == 0x0A;
+            }
+            (MbcState::Mbc5 { rom_bank, .. }, 0x2000..=0x2FFF) => {
+                *rom_bank = (*rom_bank & 0x100) | val as u16;
+            }
+            (MbcState::Mbc5 { rom_bank, .. }, 0x3000..=0x3FFF) => {
+                *rom_bank = (*rom_bank & 0xFF) | (((val & 0x01) as u16) << 8);
+            }
+            (MbcState::Mbc5 { ram_bank, .. }, 0x4000..=0x5FFF) => {
+                *ram_bank = val & 0x0F;
+            }
+            (
+                MbcState::Mbc5 {
+                    ram_enable,
+                    ram_bank,
+                    ..
+                },
+                0xA000..=0xBFFF,
+            ) => {
+                if *ram_enable {
+                    let idx = (*ram_bank as usize) * 0x2000 + addr as usize - 0xA000;
+                    if let Some(b) = self.ram.get_mut(idx) {
+                        *b = val;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn ram_index(&self, addr: u16) -> usize {
+        match &self.mbc_state {
+            MbcState::NoMbc => addr as usize - 0xA000,
+            MbcState::Mbc1 { ram_bank, mode, .. } => {
+                if *mode == 0 {
+                    addr as usize - 0xA000
+                } else {
+                    (*ram_bank as usize) * 0x2000 + addr as usize - 0xA000
+                }
+            }
+            MbcState::Mbc3 { ram_bank, .. } => {
+                (*ram_bank as usize) * 0x2000 + addr as usize - 0xA000
+            }
+            MbcState::Mbc5 { ram_bank, .. } => {
+                (*ram_bank as usize) * 0x2000 + addr as usize - 0xA000
+            }
+            MbcState::Unknown => addr as usize - 0xA000,
+        }
+    }
+
+    fn has_battery(&self) -> bool {
+        matches!(
+            self.cart_type,
+            0x03 | 0x06 | 0x09 | 0x0F | 0x10 | 0x13 | 0x1B | 0x1E
+        )
+    }
+}
+
+struct Header<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> Header<'a> {
+    fn parse(data: &'a [u8]) -> Self {
+        Self { data }
+    }
+
+    fn title(&self) -> String {
+        let end = 0x0143.min(self.data.len());
+        let mut slice = &self.data[0x0134.min(self.data.len())..end];
+        if let Some(pos) = slice.iter().position(|&b| b == 0) {
+            slice = &slice[..pos];
+        }
+        String::from_utf8_lossy(slice).trim().to_string()
+    }
+
+    fn cgb_supported(&self) -> bool {
+        self.data.get(0x0143).copied().unwrap_or(0) & 0x80 != 0
+    }
+
+    fn mbc_type(&self) -> MbcType {
+        if self.data.len() < 0x150 {
+            return MbcType::NoMbc;
+        }
+        match self.data.get(0x0147).copied().unwrap_or(0) {
+            0x00 => MbcType::NoMbc,
+            0x01..=0x03 => MbcType::Mbc1,
+            0x0F..=0x13 => MbcType::Mbc3,
+            0x19..=0x1E => MbcType::Mbc5,
+            _ => MbcType::NoMbc,
+        }
+    }
+
+    fn cart_type(&self) -> u8 {
+        if self.data.len() < 0x150 {
+            return 0x00;
+        }
+        self.data.get(0x0147).copied().unwrap_or(0)
+    }
+
+    fn ram_size(&self) -> usize {
+        if self.data.len() < 0x150 {
+            return 0x2000;
+        }
+        match self.data.get(0x0149).copied().unwrap_or(0) {
+            0x00 => 0,
+            0x01 => 0x800,   // 2KB
+            0x02 => 0x2000,  // 8KB
+            0x03 => 0x8000,  // 32KB (4 banks)
+            0x04 => 0x20000, // 128KB (16 banks)
+            0x05 => 0x10000, // 64KB (8 banks)
+            _ => 0x2000,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,9 @@ fn main() {
     let mut gb = gameboy::GameBoy::new();
 
     if let Some(path) = args.rom {
-        match std::fs::read(path) {
-            Ok(data) => {
-                gb.mmu.load_cart(cartridge::Cartridge::load(data));
+        match cartridge::Cartridge::from_file(&path) {
+            Ok(cart) => {
+                gb.mmu.load_cart(cart);
             }
             Err(e) => {
                 eprintln!("Failed to load ROM: {e}");

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -64,17 +64,9 @@ impl Mmu {
                 .as_ref()
                 .and_then(|b| b.get(addr as usize).copied())
                 .unwrap_or(0xFF),
-            0x0000..=0x7FFF => self
-                .cart
-                .as_ref()
-                .and_then(|c| c.rom.get(addr as usize).copied())
-                .unwrap_or(0xFF),
+            0x0000..=0x7FFF => self.cart.as_ref().map(|c| c.read(addr)).unwrap_or(0xFF),
             0x8000..=0x9FFF => self.vram[self.vram_bank][(addr - 0x8000) as usize],
-            0xA000..=0xBFFF => self
-                .cart
-                .as_ref()
-                .map(|c| c.read_ram(addr - 0xA000))
-                .unwrap_or(0xFF),
+            0xA000..=0xBFFF => self.cart.as_ref().map(|c| c.read(addr)).unwrap_or(0xFF),
             0xC000..=0xCFFF => self.wram[0][(addr - 0xC000) as usize],
             0xD000..=0xDFFF => self.wram[self.wram_bank][(addr - 0xD000) as usize],
             0xE000..=0xEFFF => self.wram[0][(addr - 0xE000) as usize],
@@ -101,9 +93,9 @@ impl Mmu {
             0x8000..=0x9FFF => {
                 self.vram[self.vram_bank][(addr - 0x8000) as usize] = val;
             }
-            0xA000..=0xBFFF => {
+            0x0000..=0x7FFF | 0xA000..=0xBFFF => {
                 if let Some(cart) = self.cart.as_mut() {
-                    cart.write_ram(addr - 0xA000, val);
+                    cart.write(addr, val);
                 }
             }
             0xC000..=0xCFFF => self.wram[0][(addr - 0xC000) as usize] = val,

--- a/tests/mmu.rs
+++ b/tests/mmu.rs
@@ -40,10 +40,7 @@ fn vram_bank_switch() {
 fn boot_rom_disable() {
     let mut mmu = Mmu::new();
     mmu.load_boot_rom(vec![0xAA; 0x100]);
-    mmu.load_cart(Cartridge {
-        rom: vec![0xBB; 0x200],
-        ram: vec![0; 0x2000],
-    });
+    mmu.load_cart(Cartridge::from_bytes_with_ram(vec![0xBB; 0x200], 0x2000));
     assert_eq!(mmu.read_byte(0x00), 0xAA);
     mmu.write_byte(0xFF50, 1);
     assert_eq!(mmu.read_byte(0x00), 0xBB);
@@ -52,10 +49,7 @@ fn boot_rom_disable() {
 #[test]
 fn cartridge_ram_access() {
     let mut mmu = Mmu::new();
-    mmu.load_cart(Cartridge {
-        rom: vec![0; 0x200],
-        ram: vec![0; 0x2000],
-    });
+    mmu.load_cart(Cartridge::from_bytes_with_ram(vec![0; 0x200], 0x2000));
 
     mmu.write_byte(0xA000, 0x55);
     assert_eq!(mmu.read_byte(0xA000), 0x55);


### PR DESCRIPTION
## Summary
- parse cartridge header and instantiate basic MBC state
- expose helpers to load ROMs from file or in tests
- hook cartridge reads/writes through MMU
- update tests for new cartridge API
- mark Cartridge Loading tasks complete in TODO

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684c7b913ef0832581bd4bfaa169c12f