### PR TITLE
Implement cartridge battery save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +1695,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +1854,7 @@ dependencies = [
  "env_logger",
  "log",
  "pixels",
+ "tempfile",
  "winit",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ env_logger = "0.10"
 
 [lib]
 path = "src/lib.rs"
+
+[dev-dependencies]
+tempfile = "3"

--- a/TODO.md
+++ b/TODO.md
@@ -392,7 +392,7 @@ The MMU will have to implement reads and writes to all these areas. In many case
 
 - [x] Manage external RAM: allocate a vector for it if present (size determined by cartridge header). Ensure that when RAM is “disabled” via MBC, reads return 0xFF or open-bus (and writes don’t stick).
 
-- Provide a mechanism to **save** the RAM to disk (battery-backed RAM). This could be an API call from the frontend to dump the RAM to a file when the emulator exits, and load from file when starting. It’s easiest to do this in the cartridge module as it knows the RAM size and content. (SameBoy supports battery save for game progress[sameboy.github.io](https://sameboy.github.io/features/#:~:text=,on%20a%20Game%20Boy%20Color), and we will too, but **not** emulator state save).
+- [x] Provide a mechanism to **save** the RAM to disk (battery-backed RAM). This could be an API call from the frontend to dump the RAM to a file when the emulator exits, and load from file when starting. It’s easiest to do this in the cartridge module as it knows the RAM size and content. (SameBoy supports battery save for game progress[sameboy.github.io](https://sameboy.github.io/features/#:~:text=,on%20a%20Game%20Boy%20Color), and we will too, but **not** emulator state save).
 
 - Identify cartridge type: On loading a ROM, read the header at 0x0147 to determine the MBC type and instantiate the appropriate handler[gbdev.io](https://gbdev.io/pandocs/#:~:text=32,46)[gbdev.io](https://gbdev.io/pandocs/#:~:text=36,M161). For instance, 0x01 means MBC1, 0x13 means MBC3+RAM+Battery, etc. Also check 0x014C (CGB flag) to know if game supports CGB mode (0x80 or 0xC0 means CGB capable) so we start emulator in CGB or DMG mode accordingly.
 
@@ -861,7 +861,7 @@ Implementing a full emulator is complex – breaking it into manageable pieces w
   
   - Remove or conditionalize any development logs to not flood release version.
   
-  - Ensure battery save files are written on exit (and perhaps periodically to avoid loss on crash).
+  - [x] Ensure battery save files are written on exit (and perhaps periodically to avoid loss on crash).
   
   - Graceful shutdown when window closed or user interrupts.
   

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,4 +54,6 @@ fn main() {
         "Emulator initialized in {} mode",
         if args.dmg { "DMG" } else { "CGB" }
     );
+
+    gb.mmu.save_cart_ram();
 }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -52,6 +52,14 @@ impl Mmu {
         self.cart = Some(cart);
     }
 
+    pub fn save_cart_ram(&self) {
+        if let Some(cart) = &self.cart {
+            if let Err(e) = cart.save_ram() {
+                eprintln!("Failed to save RAM: {e}");
+            }
+        }
+    }
+
     pub fn load_boot_rom(&mut self, data: Vec<u8>) {
         self.boot_rom = Some(data);
         self.boot_mapped = true;

--- a/tests/cartridge.rs
+++ b/tests/cartridge.rs
@@ -1,0 +1,22 @@
+use std::fs;
+use tempfile::tempdir;
+use vibeEmu::cartridge::Cartridge;
+
+#[test]
+fn battery_ram_saved_to_disk() {
+    let dir = tempdir().unwrap();
+    let rom_path = dir.path().join("game.gb");
+
+    let mut rom = vec![0u8; 0x8000];
+    rom[0x0147] = 0x03; // MBC1 + RAM + Battery
+    rom[0x0149] = 0x03; // 32KB RAM
+    fs::write(&rom_path, &rom).unwrap();
+
+    let mut cart = Cartridge::from_file(&rom_path).unwrap();
+    cart.ram[0] = 0xAA;
+    cart.save_ram().unwrap();
+
+    let save_path = rom_path.with_extension("sav");
+    let data = fs::read(save_path).unwrap();
+    assert_eq!(data[0], 0xAA);
+}


### PR DESCRIPTION
## Summary
- support saving cartridge RAM to disk
- expose new method on `Mmu` to persist RAM
- call RAM save on emulator exit
- add regression test for battery saves
- mark TODO items complete

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684c809bb7fc8325a7868b0c7053f12a