### PR TITLE
Implement cartridge boot ROM loading and mode detection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -394,9 +394,9 @@ The MMU will have to implement reads and writes to all these areas. In many case
 
 - [x] Provide a mechanism to **save** the RAM to disk (battery-backed RAM). This could be an API call from the frontend to dump the RAM to a file when the emulator exits, and load from file when starting. It’s easiest to do this in the cartridge module as it knows the RAM size and content. (SameBoy supports battery save for game progress[sameboy.github.io](https://sameboy.github.io/features/#:~:text=,on%20a%20Game%20Boy%20Color), and we will too, but **not** emulator state save).
 
-- Identify cartridge type: On loading a ROM, read the header at 0x0147 to determine the MBC type and instantiate the appropriate handler[gbdev.io](https://gbdev.io/pandocs/#:~:text=32,46)[gbdev.io](https://gbdev.io/pandocs/#:~:text=36,M161). For instance, 0x01 means MBC1, 0x13 means MBC3+RAM+Battery, etc. Also check 0x014C (CGB flag) to know if game supports CGB mode (0x80 or 0xC0 means CGB capable) so we start emulator in CGB or DMG mode accordingly.
+- [x] Identify cartridge type: On loading a ROM, read the header at 0x0147 to determine the MBC type and instantiate the appropriate handler[gbdev.io](https://gbdev.io/pandocs/#:~:text=32,46)[gbdev.io](https://gbdev.io/pandocs/#:~:text=36,M161). For instance, 0x01 means MBC1, 0x13 means MBC3+RAM+Battery, etc. Also check 0x014C (CGB flag) to know if game supports CGB mode (0x80 or 0xC0 means CGB capable) so we start emulator in CGB or DMG mode accordingly.
 
-- Map the **boot ROM**: Not exactly cartridge, but we should consider how to handle the boot ROM mapping. Possibly the MMU can have a flag that first 0x100 bytes come from an internal boot ROM until disabled.
+- [x] Map the **boot ROM**: Not exactly cartridge, but we should consider how to handle the boot ROM mapping. Possibly the MMU can have a flag that first 0x100 bytes come from an internal boot ROM until disabled.
 
 **Interactions:**
 

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -68,7 +68,12 @@ impl Cartridge {
             }
         }
 
-        println!("Loaded ROM: {} (MBC: {:?})", cart.title, cart.mbc);
+        println!(
+            "Loaded ROM: {} (MBC: {:?}, CGB: {})",
+            cart.title,
+            cart.mbc,
+            if cart.cgb { "yes" } else { "no" }
+        );
         Ok(cart)
     }
 

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -3,13 +3,19 @@ use crate::{cpu::Cpu, mmu::Mmu};
 pub struct GameBoy {
     pub cpu: Cpu,
     pub mmu: Mmu,
+    pub cgb: bool,
 }
 
 impl GameBoy {
     pub fn new() -> Self {
+        Self::new_with_mode(false)
+    }
+
+    pub fn new_with_mode(cgb: bool) -> Self {
         Self {
             cpu: Cpu::new(),
             mmu: Mmu::new(),
+            cgb,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,10 @@ struct Args {
     /// Run in serial test mode
     #[arg(long)]
     serial: bool,
+
+    /// Path to boot ROM file
+    #[arg(long)]
+    bootrom: Option<std::path::PathBuf>,
 }
 
 fn main() {
@@ -32,27 +36,37 @@ fn main() {
 
     info!("Starting emulator");
 
-    let mut gb = gameboy::GameBoy::new();
-
-    if let Some(path) = args.rom {
-        match cartridge::Cartridge::from_file(&path) {
-            Ok(cart) => {
-                gb.mmu.load_cart(cart);
-            }
-            Err(e) => {
-                eprintln!("Failed to load ROM: {e}");
-                return;
-            }
+    let rom_path = match args.rom {
+        Some(p) => p,
+        None => {
+            eprintln!("No ROM supplied");
+            return;
         }
-    } else {
-        eprintln!("No ROM supplied");
-        return;
+    };
+
+    let cart = match cartridge::Cartridge::from_file(&rom_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to load ROM: {e}");
+            return;
+        }
+    };
+
+    let cgb_mode = if args.dmg { false } else { cart.cgb };
+    let mut gb = gameboy::GameBoy::new_with_mode(cgb_mode);
+    gb.mmu.load_cart(cart);
+
+    if let Some(path) = args.bootrom {
+        match std::fs::read(&path) {
+            Ok(data) => gb.mmu.load_boot_rom(data),
+            Err(e) => eprintln!("Failed to load boot ROM: {e}"),
+        }
     }
 
     // TODO: main emulation loop will go here
     println!(
         "Emulator initialized in {} mode",
-        if args.dmg { "DMG" } else { "CGB" }
+        if cgb_mode { "CGB" } else { "DMG" }
     );
 
     gb.mmu.save_cart_ram();


### PR DESCRIPTION
## Summary
- auto-detect cartridge CGB capability and print it
- provide boot ROM loading via `--bootrom` argument
- expose cartridge mode choice through `GameBoy::new_with_mode`
- mark related TODO items complete

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684c8230a0588325a62e12528bb3db3a