### PR TITLE
Implement basic PPU state and timing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -659,14 +659,14 @@ Implementing a full emulator is complex – breaking it into manageable pieces w
 
 - **PPU Implementation (Rendering)** – *Dep: CPU (for timing), MMU (for memory interface).*
   
-  - Implement PPU registers and internal data:  
-    
-    * LCDC (FF40) bits: control enabling BG, sprites, sprite size, BG tilemap base, tile data base, window enable, window tilemap base, LCD on/off.  
-    * STAT (FF41) bits: the mode bits (0-1), coincidence flag (bit2), and interrupt enable flags for LY=LYC, OAM, VBlank, HBlank.  
-    * SCY, SCX (scroll), LY, LYC, WY, WX, BGP, OBP0, OBP1 (DMG palettes).  
-    * If CGB mode: BG palette index/register (FF68/69) and OBJ palette index/register (FF6A/6B), which allow access to CGB palette tables.  
-    * OAM memory for 40 sprites (each 4 bytes: y, x, tile, flags).  
-    * VRAM memory for tiles and maps (with 2 banks in CGB).
+  - Implement PPU registers and internal data:
+
+    * [x] LCDC (FF40) bits: control enabling BG, sprites, sprite size, BG tilemap base, tile data base, window enable, window tilemap base, LCD on/off.
+    * [x] STAT (FF41) bits: the mode bits (0-1), coincidence flag (bit2), and interrupt enable flags for LY=LYC, OAM, VBlank, HBlank.
+    * [x] SCY, SCX (scroll), LY, LYC, WY, WX, BGP, OBP0, OBP1 (DMG palettes).
+    * [x] If CGB mode: BG palette index/register (FF68/69) and OBJ palette index/register (FF6A/6B), which allow access to CGB palette tables.
+    * [x] OAM memory for 40 sprites (each 4 bytes: y, x, tile, flags).
+    * [x] VRAM memory for tiles and maps (with 2 banks in CGB).
   
   - PPU step function:  
     

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -257,7 +257,7 @@ impl Cpu {
         (hi << 8) | lo
     }
 
-    fn read_reg(&self, mmu: &crate::mmu::Mmu, index: u8) -> u8 {
+    fn read_reg(&self, mmu: &mut crate::mmu::Mmu, index: u8) -> u8 {
         match index {
             0 => self.b,
             1 => self.c,

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -1,15 +1,11 @@
 use crate::{apu::Apu, cartridge::Cartridge, input::Input, ppu::Ppu, timer::Timer};
 
 const WRAM_BANK_SIZE: usize = 0x1000;
-const VRAM_BANK_SIZE: usize = 0x2000;
 
 pub struct Mmu {
     pub wram: [[u8; WRAM_BANK_SIZE]; 8],
     pub wram_bank: usize,
-    pub vram: [[u8; VRAM_BANK_SIZE]; 2],
-    pub vram_bank: usize,
     pub hram: [u8; 0x7F],
-    pub oam: [u8; 0xA0],
     pub cart: Option<Cartridge>,
     pub boot_rom: Option<Vec<u8>>,
     pub boot_mapped: bool,
@@ -29,10 +25,7 @@ impl Mmu {
         Self {
             wram: [[0; WRAM_BANK_SIZE]; 8],
             wram_bank: 1,
-            vram: [[0; VRAM_BANK_SIZE]; 2],
-            vram_bank: 0,
             hram: [0; 0x7F],
-            oam: [0; 0xA0],
             cart: None,
             boot_rom: None,
             boot_mapped: false,
@@ -65,7 +58,7 @@ impl Mmu {
         self.boot_mapped = true;
     }
 
-    pub fn read_byte(&self, addr: u16) -> u8 {
+    pub fn read_byte(&mut self, addr: u16) -> u8 {
         match addr {
             0x0000..=0x00FF if self.boot_mapped => self
                 .boot_rom
@@ -73,13 +66,13 @@ impl Mmu {
                 .and_then(|b| b.get(addr as usize).copied())
                 .unwrap_or(0xFF),
             0x0000..=0x7FFF => self.cart.as_ref().map(|c| c.read(addr)).unwrap_or(0xFF),
-            0x8000..=0x9FFF => self.vram[self.vram_bank][(addr - 0x8000) as usize],
+            0x8000..=0x9FFF => self.ppu.vram[self.ppu.vram_bank][(addr - 0x8000) as usize],
             0xA000..=0xBFFF => self.cart.as_ref().map(|c| c.read(addr)).unwrap_or(0xFF),
             0xC000..=0xCFFF => self.wram[0][(addr - 0xC000) as usize],
             0xD000..=0xDFFF => self.wram[self.wram_bank][(addr - 0xD000) as usize],
             0xE000..=0xEFFF => self.wram[0][(addr - 0xE000) as usize],
             0xF000..=0xFDFF => self.wram[self.wram_bank][(addr - 0xF000) as usize],
-            0xFE00..=0xFE9F => self.oam[(addr - 0xFE00) as usize],
+            0xFE00..=0xFE9F => self.ppu.oam[(addr - 0xFE00) as usize],
             0xFEA0..=0xFEFF => 0xFF,
             0xFF00 => self.input.read(),
             0xFF01 => self.sb,
@@ -87,8 +80,8 @@ impl Mmu {
             0xFF04..=0xFF07 => self.timer.read(addr),
             0xFF0F => self.if_reg,
             0xFF10..=0xFF3F => self.apu.read_reg(addr),
-            0xFF40..=0xFF4B => self.ppu.read_reg(addr),
-            0xFF4F => self.vram_bank as u8,
+            0xFF40..=0xFF4B | 0xFF68..=0xFF6B => self.ppu.read_reg(addr),
+            0xFF4F => self.ppu.vram_bank as u8,
             0xFF70 => self.wram_bank as u8,
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
             0xFFFF => self.ie_reg,
@@ -99,7 +92,7 @@ impl Mmu {
     pub fn write_byte(&mut self, addr: u16, val: u8) {
         match addr {
             0x8000..=0x9FFF => {
-                self.vram[self.vram_bank][(addr - 0x8000) as usize] = val;
+                self.ppu.vram[self.ppu.vram_bank][(addr - 0x8000) as usize] = val;
             }
             0x0000..=0x7FFF | 0xA000..=0xBFFF => {
                 if let Some(cart) = self.cart.as_mut() {
@@ -110,7 +103,7 @@ impl Mmu {
             0xD000..=0xDFFF => self.wram[self.wram_bank][(addr - 0xD000) as usize] = val,
             0xE000..=0xEFFF => self.wram[0][(addr - 0xE000) as usize] = val,
             0xF000..=0xFDFF => self.wram[self.wram_bank][(addr - 0xF000) as usize] = val,
-            0xFE00..=0xFE9F => self.oam[(addr - 0xFE00) as usize] = val,
+            0xFE00..=0xFE9F => self.ppu.oam[(addr - 0xFE00) as usize] = val,
             0xFEA0..=0xFEFF => {}
             0xFF00 => self.input.write(val),
             0xFF01 => self.sb = val,
@@ -125,8 +118,8 @@ impl Mmu {
             0xFF04..=0xFF07 => self.timer.write(addr, val),
             0xFF0F => self.if_reg = val,
             0xFF10..=0xFF3F => self.apu.write_reg(addr, val),
-            0xFF40..=0xFF4B => self.ppu.write_reg(addr, val),
-            0xFF4F => self.vram_bank = (val & 0x01) as usize,
+            0xFF40..=0xFF4B | 0xFF68..=0xFF6B => self.ppu.write_reg(addr, val),
+            0xFF4F => self.ppu.vram_bank = (val & 0x01) as usize,
             0xFF50 => self.boot_mapped = false,
             0xFF70 => {
                 let bank = (val & 0x07) as usize;

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -1,22 +1,179 @@
 pub struct Ppu {
-    pub vram: [u8; 0x2000],
-    regs: [u8; 0x0C],
+    pub vram: [[u8; 0x2000]; 2],
+    pub vram_bank: usize,
+    pub oam: [u8; 0xA0],
+
+    lcdc: u8,
+    stat: u8,
+    scy: u8,
+    scx: u8,
+    ly: u8,
+    lyc: u8,
+    dma: u8,
+    bgp: u8,
+    obp0: u8,
+    obp1: u8,
+    wy: u8,
+    wx: u8,
+
+    bgpi: u8,
+    bgpd: [u8; 0x40],
+    obpi: u8,
+    obpd: [u8; 0x40],
+
+    mode_clock: u16,
+    mode: u8,
+
+    pub framebuffer: [u8; 160 * 144],
 }
 
 impl Ppu {
     pub fn new() -> Self {
         Self {
-            vram: [0; 0x2000],
-            regs: [0; 0x0C],
+            vram: [[0; 0x2000]; 2],
+            vram_bank: 0,
+            oam: [0; 0xA0],
+            lcdc: 0,
+            stat: 0,
+            scy: 0,
+            scx: 0,
+            ly: 0,
+            lyc: 0,
+            dma: 0,
+            bgp: 0,
+            obp0: 0,
+            obp1: 0,
+            wy: 0,
+            wx: 0,
+            bgpi: 0,
+            bgpd: [0; 0x40],
+            obpi: 0,
+            obpd: [0; 0x40],
+            mode_clock: 0,
+            mode: 2,
+            framebuffer: [0; 160 * 144],
         }
     }
 
-    pub fn read_reg(&self, addr: u16) -> u8 {
-        self.regs[(addr - 0xFF40) as usize]
+    pub fn read_reg(&mut self, addr: u16) -> u8 {
+        match addr {
+            0xFF40 => self.lcdc,
+            0xFF41 => {
+                (self.stat & 0x78) | (self.mode & 0x03) | if self.ly == self.lyc { 0x04 } else { 0 }
+            }
+            0xFF42 => self.scy,
+            0xFF43 => self.scx,
+            0xFF44 => self.ly,
+            0xFF45 => self.lyc,
+            0xFF46 => self.dma,
+            0xFF47 => self.bgp,
+            0xFF48 => self.obp0,
+            0xFF49 => self.obp1,
+            0xFF4A => self.wy,
+            0xFF4B => self.wx,
+            0xFF68 => self.bgpi,
+            0xFF69 => self.bgpd[(self.bgpi & 0x3F) as usize],
+            0xFF6A => self.obpi,
+            0xFF6B => self.obpd[(self.obpi & 0x3F) as usize],
+            _ => 0xFF,
+        }
     }
 
     pub fn write_reg(&mut self, addr: u16, val: u8) {
-        self.regs[(addr - 0xFF40) as usize] = val;
+        match addr {
+            0xFF40 => self.lcdc = val,
+            0xFF41 => self.stat = (self.stat & 0x07) | (val & 0xF8),
+            0xFF42 => self.scy = val,
+            0xFF43 => self.scx = val,
+            0xFF44 => {}
+            0xFF45 => self.lyc = val,
+            0xFF46 => self.dma = val,
+            0xFF47 => self.bgp = val,
+            0xFF48 => self.obp0 = val,
+            0xFF49 => self.obp1 = val,
+            0xFF4A => self.wy = val,
+            0xFF4B => self.wx = val,
+            0xFF68 => self.bgpi = val,
+            0xFF69 => {
+                let idx = (self.bgpi & 0x3F) as usize;
+                self.bgpd[idx] = val;
+                if self.bgpi & 0x80 != 0 {
+                    self.bgpi = (self.bgpi & 0x80) | ((idx as u8 + 1) & 0x3F);
+                }
+            }
+            0xFF6A => self.obpi = val,
+            0xFF6B => {
+                let idx = (self.obpi & 0x3F) as usize;
+                self.obpd[idx] = val;
+                if self.obpi & 0x80 != 0 {
+                    self.obpi = (self.obpi & 0x80) | ((idx as u8 + 1) & 0x3F);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn step(&mut self, cycles: u16, if_reg: &mut u8) {
+        let mut remaining = cycles;
+        while remaining > 0 {
+            let increment = remaining.min(4);
+            remaining -= increment;
+            self.mode_clock += increment;
+
+            match self.mode {
+                0 => {
+                    if self.mode_clock >= 204 {
+                        self.mode_clock -= 204;
+                        self.ly += 1;
+                        if self.ly == 144 {
+                            self.mode = 1;
+                            if self.stat & 0x10 != 0 {
+                                *if_reg |= 0x02;
+                            }
+                            *if_reg |= 0x01;
+                        } else {
+                            self.mode = 2;
+                            if self.stat & 0x20 != 0 {
+                                *if_reg |= 0x02;
+                            }
+                        }
+                    }
+                }
+                1 => {
+                    if self.mode_clock >= 456 {
+                        self.mode_clock -= 456;
+                        self.ly += 1;
+                        if self.ly > 153 {
+                            self.ly = 0;
+                            self.mode = 2;
+                            if self.stat & 0x20 != 0 {
+                                *if_reg |= 0x02;
+                            }
+                        }
+                    }
+                }
+                2 => {
+                    if self.mode_clock >= 80 {
+                        self.mode_clock -= 80;
+                        self.mode = 3;
+                    }
+                }
+                3 => {
+                    if self.mode_clock >= 172 {
+                        self.mode_clock -= 172;
+                        self.mode = 0;
+                        if self.stat & 0x08 != 0 {
+                            *if_reg |= 0x02;
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            if self.ly == self.lyc && self.stat & 0x40 != 0 {
+                *if_reg |= 0x02;
+            }
+        }
     }
 }
 

--- a/tests/ppu.rs
+++ b/tests/ppu.rs
@@ -1,0 +1,35 @@
+use vibeEmu::ppu::Ppu;
+
+#[test]
+fn register_access() {
+    let mut ppu = Ppu::new();
+    ppu.write_reg(0xFF40, 0x91);
+    ppu.write_reg(0xFF47, 0xFC);
+    ppu.write_reg(0xFF4A, 0x01);
+    ppu.write_reg(0xFF4B, 0x20);
+    assert_eq!(ppu.read_reg(0xFF40), 0x91);
+    assert_eq!(ppu.read_reg(0xFF47), 0xFC);
+    assert_eq!(ppu.read_reg(0xFF4A), 0x01);
+    assert_eq!(ppu.read_reg(0xFF4B), 0x20);
+
+    // write palette data with auto-increment
+    ppu.write_reg(0xFF68, 0x83); // index 3, auto-inc
+    ppu.write_reg(0xFF69, 0xAA);
+    ppu.write_reg(0xFF69, 0x55);
+    assert_eq!(ppu.read_reg(0xFF68) & 0x3F, 5);
+    // read back first written entry
+    ppu.write_reg(0xFF68, 0x03);
+    assert_eq!(ppu.read_reg(0xFF69), 0xAA);
+}
+
+#[test]
+fn step_vblank_interrupt() {
+    let mut ppu = Ppu::new();
+    let mut if_reg = 0u8;
+    for _ in 0..144 {
+        ppu.step(456, &mut if_reg);
+    }
+    assert_eq!(ppu.read_reg(0xFF44), 144);
+    assert_eq!(ppu.read_reg(0xFF41) & 0x03, 1); // mode 1
+    assert!(if_reg & 0x01 != 0);
+}


### PR DESCRIPTION
## Summary
- flesh out `Ppu` with VRAM/OAM and register storage
- implement a simple timing based `step` method
- update MMU to use the PPU for VRAM/OAM and palette registers
- adjust CPU and tests for new MMU mutability
- add initial unit tests for the PPU
- mark completed items in TODO

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684c8655562c8325a00380d344e4df3f