### PR TITLE
timer module stepping

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -715,19 +715,18 @@ Implementing a full emulator is complex – breaking it into manageable pieces w
 
 - [ ] **Timers & DIV** – *Dep: CPU (timing), MMU.*
   
-  - [ ] Implement the Timer module fully as described:  
-    
-    * [ ] Keep track of `div_counter` (16-bit). Perhaps every CPU cycle call `timer.tick()`.  
-    * [ ] When `div_counter` overflows 0xFFFF -> 0x0000, it automatically wraps (DIV register goes through 00-FF).  
-    * [ ] Use TAC to determine when to increment TIMA. Simplest: whenever the specific bit of `div_counter` goes from 1 to 0 (falling edge) as per TAC selection, increment TIMA (if timer enabled). Use Pan Docs schematic[gbdev.io](https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html#:~:text=On%20DMG%3A) or simpler approach: maintain a separate counter for TIMA that counts down cycles until next increment.  
-    * [ ] If TIMA overflows, set TIMA = TMA, request interrupt.  
-    * [ ] Respond correctly to writes:  
+  - [ ] Implement the Timer module fully as described:
+    * [x] Keep track of `div_counter` (16-bit). Perhaps every CPU cycle call `timer.tick()`.
+    * [x] When `div_counter` overflows 0xFFFF -> 0x0000, it automatically wraps (DIV register goes through 00-FF).
+    * [x] Use TAC to determine when to increment TIMA. Simplest: whenever the specific bit of `div_counter` goes from 1 to 0 (falling edge) as per TAC selection, increment TIMA (if timer enabled). Use Pan Docs schematic[gbdev.io](https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html#:~:text=On%20DMG%3A) or simpler approach: maintain a separate counter for TIMA that counts down cycles until next increment.
+    * [x] If TIMA overflows, set TIMA = TMA, request interrupt.
+    * [ ] Respond correctly to writes:
     - [ ] Write to DIV: set div_counter = 0 (and thus DIV=0). Also, in doing so, handle the edge-case: if the timer was about to tick at that moment, do we skip it or not? (This is a subtle detail; tests exist for it. We can refine later.)  
-    - [ ] Write to TAC: note if enabling/disabling timer might immediately cause a tick depending on counter state.  
-    - [ ] Write to TIMA: if an overflow was in progress (there’s a known glitch where writing TIMA in the short window after overflow and before it reloads from TMA cancels the interrupt). We can simplify initial implementation by ignoring that glitch, then later add if needed for passing test ROMs.  
-    * [ ] Write to TMA: simply sets the modulo for future overflow reload.
+    - [ ] Write to TAC: note if enabling/disabling timer might immediately cause a tick depending on counter state.
+    - [x] Write to TIMA: if an overflow was in progress (there’s a known glitch where writing TIMA in the short window after overflow and before it reloads from TMA cancels the interrupt). We can simplify initial implementation by ignoring that glitch, then later add if needed for passing test ROMs.
+    * [x] Write to TMA: simply sets the modulo for future overflow reload.
   
-  - [ ] Integrate with MMU reads/writes (some done in MMU step above).
+  - [x] Integrate with MMU reads/writes (some done in MMU step above).
   
   - [ ] Test: Use known timer test ROMs from mooneye or blargg (e.g., “timer/div behavior” tests). Also, verify in a game that uses timer (some games use timer interrupt for periodic tasks – if those tasks happen or not can be noticed).
   

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -410,6 +410,7 @@ impl Cpu {
     pub fn step(&mut self, mmu: &mut crate::mmu::Mmu) {
         if self.halted {
             self.cycles += 4;
+            mmu.timer.step(4, &mut mmu.if_reg);
             self.handle_interrupts(mmu);
             return;
         }
@@ -1387,7 +1388,9 @@ impl Cpu {
             _ => panic!("unhandled opcode {:02X}", opcode),
         }
 
-        self.cycles += OPCODE_CYCLES[opcode as usize] as u64 + extra_cycles as u64;
+        let cycles = OPCODE_CYCLES[opcode as usize] as u16 + extra_cycles as u16;
+        self.cycles += cycles as u64;
+        mmu.timer.step(cycles, &mut mmu.if_reg);
 
         if enable_after {
             self.ime = true;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,8 +1,13 @@
 pub struct Timer {
+    /// 16-bit internal divider counter. DIV register is the upper 8 bits.
     pub div: u16,
+    /// Timer counter
     pub tima: u8,
+    /// Timer modulo
     pub tma: u8,
+    /// Timer control
     pub tac: u8,
+    last_bit: bool,
 }
 
 impl Timer {
@@ -12,6 +17,7 @@ impl Timer {
             tima: 0,
             tma: 0,
             tac: 0,
+            last_bit: false,
         }
     }
 
@@ -27,11 +33,46 @@ impl Timer {
 
     pub fn write(&mut self, addr: u16, val: u8) {
         match addr {
-            0xFF04 => self.div = 0,
+            0xFF04 => {
+                self.div = 0;
+                self.last_bit = false;
+            }
             0xFF05 => self.tima = val,
             0xFF06 => self.tma = val,
-            0xFF07 => self.tac = val & 0x07,
+            0xFF07 => {
+                self.tac = val & 0x07;
+                self.last_bit = self.timer_bit() != 0;
+            }
             _ => {}
+        }
+    }
+
+    /// Advance the timer by `cycles` CPU cycles and update IF when TIMA
+    /// overflows.
+    pub fn step(&mut self, cycles: u16, if_reg: &mut u8) {
+        for _ in 0..cycles {
+            let prev_bit = self.timer_bit();
+            self.div = self.div.wrapping_add(1);
+            let new_bit = self.timer_bit();
+            if self.tac & 0x04 != 0 && prev_bit == 1 && new_bit == 0 {
+                if self.tima == 0xFF {
+                    self.tima = self.tma;
+                    *if_reg |= 0x04;
+                } else {
+                    self.tima = self.tima.wrapping_add(1);
+                }
+            }
+        }
+        self.last_bit = self.timer_bit() != 0;
+    }
+
+    fn timer_bit(&self) -> u8 {
+        match self.tac & 0x03 {
+            0x00 => ((self.div >> 9) & 1) as u8,
+            0x01 => ((self.div >> 3) & 1) as u8,
+            0x02 => ((self.div >> 5) & 1) as u8,
+            0x03 => ((self.div >> 7) & 1) as u8,
+            _ => 0,
         }
     }
 }

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -1,0 +1,27 @@
+use vibeEmu::timer::Timer;
+
+#[test]
+fn div_increment() {
+    let mut t = Timer::new();
+    let mut if_reg = 0u8;
+    t.step(256, &mut if_reg);
+    assert_eq!(t.read(0xFF04), 1);
+    assert_eq!(if_reg, 0);
+}
+
+#[test]
+fn tima_increment_and_overflow() {
+    let mut t = Timer::new();
+    let mut if_reg = 0u8;
+    // enable timer, freq 00 (4096 Hz -> bit 9)
+    t.write(0xFF07, 0x04); // enable
+    t.step(1024, &mut if_reg);
+    assert_eq!(t.tima, 1);
+    assert_eq!(if_reg, 0);
+
+    t.tima = 0xFF;
+    t.tma = 0xAB;
+    t.step(1024, &mut if_reg);
+    assert_eq!(t.tima, 0xAB);
+    assert_eq!(if_reg & 0x04, 0x04);
+}


### PR DESCRIPTION
## Summary
- implement basic timer counters and step function
- tick timer from CPU
- add unit tests for DIV and TIMA behavior
- update TODO progress for timer tasks

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_684c9eec97ac8325980fdf6736620a59