### PR TITLE
Implement timer DIV/TAC write behavior

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -720,9 +720,9 @@ Implementing a full emulator is complex – breaking it into manageable pieces w
     * [x] When `div_counter` overflows 0xFFFF -> 0x0000, it automatically wraps (DIV register goes through 00-FF).
     * [x] Use TAC to determine when to increment TIMA. Simplest: whenever the specific bit of `div_counter` goes from 1 to 0 (falling edge) as per TAC selection, increment TIMA (if timer enabled). Use Pan Docs schematic[gbdev.io](https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html#:~:text=On%20DMG%3A) or simpler approach: maintain a separate counter for TIMA that counts down cycles until next increment.
     * [x] If TIMA overflows, set TIMA = TMA, request interrupt.
-    * [ ] Respond correctly to writes:
-    - [ ] Write to DIV: set div_counter = 0 (and thus DIV=0). Also, in doing so, handle the edge-case: if the timer was about to tick at that moment, do we skip it or not? (This is a subtle detail; tests exist for it. We can refine later.)  
-    - [ ] Write to TAC: note if enabling/disabling timer might immediately cause a tick depending on counter state.
+  * [ ] Respond correctly to writes:
+  - [x] Write to DIV: set div_counter = 0 (and thus DIV=0). Also, in doing so, handle the edge-case: if the timer was about to tick at that moment, do we skip it or not? (This is a subtle detail; tests exist for it. We can refine later.)
+  - [x] Write to TAC: note if enabling/disabling timer might immediately cause a tick depending on counter state.
     - [x] Write to TIMA: if an overflow was in progress (there’s a known glitch where writing TIMA in the short window after overflow and before it reloads from TMA cancels the interrupt). We can simplify initial implementation by ignoring that glitch, then later add if needed for passing test ROMs.
     * [x] Write to TMA: simply sets the modulo for future overflow reload.
   

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -137,7 +137,7 @@ impl Mmu {
                     self.sc &= 0x7F;
                 }
             }
-            0xFF04..=0xFF07 => self.timer.write(addr, val),
+            0xFF04..=0xFF07 => self.timer.write(addr, val, &mut self.if_reg),
             0xFF0F => self.if_reg = val,
             0xFF10..=0xFF3F => self.apu.write_reg(addr, val),
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B | 0xFF68..=0xFF6B => self.ppu.write_reg(addr, val),

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -10,11 +10,33 @@ fn div_increment() {
 }
 
 #[test]
+fn div_reset_edge_tick() {
+    let mut t = Timer::new();
+    let mut if_reg = 0u8;
+    t.div = 0x0200; // timer bit high
+    t.write(0xFF07, 0x04, &mut if_reg); // enable, freq 4096Hz (bit9)
+    t.write(0xFF04, 0, &mut if_reg); // reset DIV causes falling edge
+    assert_eq!(t.tima, 1);
+    assert_eq!(if_reg, 0);
+}
+
+#[test]
+fn tac_disable_edge_tick() {
+    let mut t = Timer::new();
+    let mut if_reg = 0u8;
+    t.div = 0x0200; // bit9 high
+    t.write(0xFF07, 0x04, &mut if_reg); // enable
+    t.write(0xFF07, 0x00, &mut if_reg); // disable -> falling edge
+    assert_eq!(t.tima, 1);
+    assert_eq!(if_reg, 0);
+}
+
+#[test]
 fn tima_increment_and_overflow() {
     let mut t = Timer::new();
     let mut if_reg = 0u8;
     // enable timer, freq 00 (4096 Hz -> bit 9)
-    t.write(0xFF07, 0x04); // enable
+    t.write(0xFF07, 0x04, &mut if_reg); // enable
     t.step(1024, &mut if_reg);
     assert_eq!(t.tima, 1);
     assert_eq!(if_reg, 0);


### PR DESCRIPTION
## Summary
- handle DIV and TAC write edge cases in the timer
- wire updated timer write API into MMU
- expand timer tests for DIV reset and TAC disable cases
- mark TODO items as complete

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ca180289c8325b6f05c90c0c24171