### PR TITLE
Add debug logging option

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -306,6 +306,20 @@ impl Cpu {
         self.l = val as u8;
     }
 
+    /// Return a formatted string of the current CPU state for debugging.
+    pub fn debug_state(&self) -> String {
+        format!(
+            "AF:{:04X} BC:{:04X} DE:{:04X} HL:{:04X} PC:{:04X} SP:{:04X} CY:{}",
+            ((self.a as u16) << 8) | self.f as u16,
+            ((self.b as u16) << 8) | self.c as u16,
+            ((self.d as u16) << 8) | self.e as u16,
+            self.get_hl(),
+            self.pc,
+            self.sp,
+            self.cycles
+        )
+    }
+
     fn push_stack(&mut self, mmu: &mut crate::mmu::Mmu, val: u16) {
         self.sp = self.sp.wrapping_sub(1);
         mmu.write_byte(self.sp, (val >> 8) as u8);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,10 @@ struct Args {
     /// Path to boot ROM file
     #[arg(long)]
     bootrom: Option<std::path::PathBuf>,
+
+    /// Enable debug logging of CPU state and serial output
+    #[arg(long)]
+    debug: bool,
 }
 
 fn main() {
@@ -126,6 +130,23 @@ fn main() {
         window
             .update_with_buffer(&frame, 160, 144)
             .expect("Failed to update window");
+
+        if args.debug {
+            let serial = gb.mmu.take_serial();
+            if !serial.is_empty() {
+                print!("[SERIAL] ");
+                for b in &serial {
+                    if b.is_ascii_graphic() || *b == b' ' {
+                        print!("{}", *b as char);
+                    } else {
+                        print!("\\x{:02X}", b);
+                    }
+                }
+                println!();
+            }
+
+            println!("{}", gb.cpu.debug_state());
+        }
     }
 
     gb.mmu.save_cart_ram();


### PR DESCRIPTION
## Summary
- add `--debug` CLI flag
- print serial output and CPU state when debug flag is set

## Testing
- `cargo clippy`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_684cc338b80883258b46a6ee081db3fb