### PR TITLE
Fix PPU timing

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1487,8 +1487,9 @@ impl Cpu {
 
         let cycles = OPCODE_CYCLES[opcode as usize] as u16 + extra_cycles as u16;
         self.cycles += cycles as u64;
+        let dots = cycles * 4;
         mmu.timer.step(cycles, &mut mmu.if_reg);
-        mmu.ppu.step(cycles, &mut mmu.if_reg);
+        mmu.ppu.step(dots, &mut mmu.if_reg);
 
         if enable_after {
             self.ime = true;


### PR DESCRIPTION
## Summary
- feed dot cycles to the PPU so each scan line completes

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_684cd2552cb08325aef89248ba837ae9