### PR TITLE
Add CGB palette rendering

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -196,7 +196,7 @@ This section details each major module in the emulator core, its role, and how i
 
 - Constructing each scanline’s pixel data by reading background tile maps, window tile maps, tile patterns, and sprite data, obeying priorities and attribute flags (flips, palette, behind-background flags, etc.).
 
-- Managing palettes: On DMG, there are 4 shades of gray and two palette registers (BG and OBJ palettes) that assign those shades to color indices. On CGB, there are 8 palettes for background and 8 for sprites, each with 4 colors (from a 15-bit RGB palette), and these are stored in separate palette RAM. The PPU must apply the correct palette to each pixel.
+- [x] Managing palettes: On DMG, there are 4 shades of gray and two palette registers (BG and OBJ palettes) that assign those shades to color indices. On CGB, there are 8 palettes for background and 8 for sprites, each with 4 colors (from a 15-bit RGB palette), and these are stored in separate palette RAM. The PPU must apply the correct palette to each pixel.
 
 - Triggering **LCD STAT interrupts** for various conditions: LY==LYC compare, mode transition interrupts (OAM (mode2) interrupt, VBlank (mode1) interrupt, HBlank (mode0) if enabled).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,12 +78,6 @@ fn main() {
         if cgb_mode { "CGB" } else { "DMG" }
     );
 
-    let palette: [u32; 4] = if cgb_mode {
-        [0xFFFFFFFF, 0xAAAAAAFF, 0x555555FF, 0x000000FF]
-    } else {
-        // classic DMG green shades
-        [0x9BBC0FFF, 0x8BAC0FFF, 0x306230FF, 0x0F380FFF]
-    };
     let mut frame = vec![0u32; 160 * 144];
     let mut frame_count = 0u64;
 
@@ -133,9 +127,7 @@ fn main() {
                 gb.cpu.step(&mut gb.mmu);
             }
 
-            for (i, &px) in gb.mmu.ppu.framebuffer().iter().enumerate() {
-                frame[i] = palette[px as usize];
-            }
+            frame.copy_from_slice(gb.mmu.ppu.framebuffer());
             gb.mmu.ppu.clear_frame_flag();
 
             window
@@ -159,7 +151,6 @@ fn main() {
                 println!("{}", gb.cpu.debug_state());
             }
 
-            let non_zero = frame.iter().filter(|&&v| v != palette[0]).count();
             frame_count += 1;
         }
     } else {
@@ -169,9 +160,7 @@ fn main() {
                 gb.cpu.step(&mut gb.mmu);
             }
 
-            for (i, &px) in gb.mmu.ppu.framebuffer().iter().enumerate() {
-                frame[i] = palette[px as usize];
-            }
+            frame.copy_from_slice(gb.mmu.ppu.framebuffer());
             gb.mmu.ppu.clear_frame_flag();
 
             if args.debug && frame_count % 60 == 0 {
@@ -191,7 +180,6 @@ fn main() {
                 println!("{}", gb.cpu.debug_state());
             }
 
-            let non_zero = frame.iter().filter(|&&v| v != palette[0]).count();
             frame_count += 1;
         }
     }

--- a/tests/ppu.rs
+++ b/tests/ppu.rs
@@ -49,8 +49,8 @@ fn render_bg_scanline() {
     ppu.vram[0][0x1800] = 0x00;
     let mut if_reg = 0u8;
     ppu.step(456, &mut if_reg);
-    assert_eq!(ppu.framebuffer[0], 1);
-    assert_eq!(ppu.framebuffer[7], 1);
+    assert_eq!(ppu.framebuffer[0], 0x8BAC0FFF);
+    assert_eq!(ppu.framebuffer[7], 0x8BAC0FFF);
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn render_window_scanline() {
     ppu.vram[0][0x1800] = 0x01;
     let mut if_reg = 0u8;
     ppu.step(456, &mut if_reg);
-    assert_eq!(ppu.framebuffer[0], 1);
+    assert_eq!(ppu.framebuffer[0], 0x8BAC0FFF);
 }
 
 #[test]
@@ -85,5 +85,26 @@ fn render_sprite_scanline() {
     ppu.oam[3] = 0; // flags
     let mut if_reg = 0u8;
     ppu.step(456, &mut if_reg);
-    assert_eq!(ppu.framebuffer[0], 1);
+    assert_eq!(ppu.framebuffer[0], 0x8BAC0FFF);
+}
+
+#[test]
+fn cgb_bg_palette() {
+    let mut ppu = Ppu::new_with_mode(true);
+    ppu.write_reg(0xFF40, 0x91);
+    // palette 2 color 1 -> red
+    ppu.write_reg(0xFF68, 0x80 | 0x10); // index 0x10 with auto inc
+    ppu.write_reg(0xFF69, 0x00); // color 0
+    ppu.write_reg(0xFF69, 0x00);
+    ppu.write_reg(0xFF69, 0x1F); // color 1 lo
+    ppu.write_reg(0xFF69, 0x00); // color 1 hi
+    for i in 0..8 {
+        ppu.vram[0][i * 2] = 0xFF;
+        ppu.vram[0][i * 2 + 1] = 0x00;
+    }
+    ppu.vram[0][0x1800] = 0x00;
+    ppu.vram[1][0x1800] = 0x02; // use palette 2
+    let mut if_reg = 0u8;
+    ppu.step(456, &mut if_reg);
+    assert_eq!(ppu.framebuffer[0], 0xFF0000FF);
 }


### PR DESCRIPTION
## Summary
- render using CGB palette RAM
- store pixels as u32 colors and decode CGB palette entries
- update main to copy full-color framebuffer
- extend PPU tests for CGB palette support
- mark TODO for palette handling done

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_684ced26bd6883259eeee9c9255b992a