### PR TITLE
Fix DMG palette color order

### DIFF
--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -33,7 +33,8 @@ pub struct Ppu {
     frame_ready: bool,
 }
 
-const DMG_PALETTE: [u32; 4] = [0x9BBC0FFF, 0x8BAC0FFF, 0x306230FF, 0x0F380FFF];
+/// Default DMG palette colors in 0x00RRGGBB order for `minifb`.
+const DMG_PALETTE: [u32; 4] = [0x009BBC0F, 0x008BAC0F, 0x00306230, 0x000F380F];
 
 impl Ppu {
     pub fn new_with_mode(cgb: bool) -> Self {
@@ -76,7 +77,7 @@ impl Ppu {
         let r = ((raw & 0x1F) as u8) << 3 | ((raw & 0x1F) as u8 >> 2);
         let g = (((raw >> 5) & 0x1F) as u8) << 3 | (((raw >> 5) & 0x1F) as u8 >> 2);
         let b = (((raw >> 10) & 0x1F) as u8) << 3 | (((raw >> 10) & 0x1F) as u8 >> 2);
-        ((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | 0xFF
+        ((r as u32) << 16) | ((g as u32) << 8) | b as u32
     }
 
     /// Initialize registers to the state expected after the boot ROM

--- a/tests/ppu.rs
+++ b/tests/ppu.rs
@@ -49,8 +49,8 @@ fn render_bg_scanline() {
     ppu.vram[0][0x1800] = 0x00;
     let mut if_reg = 0u8;
     ppu.step(456, &mut if_reg);
-    assert_eq!(ppu.framebuffer[0], 0x8BAC0FFF);
-    assert_eq!(ppu.framebuffer[7], 0x8BAC0FFF);
+    assert_eq!(ppu.framebuffer[0], 0x008BAC0F);
+    assert_eq!(ppu.framebuffer[7], 0x008BAC0F);
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn render_window_scanline() {
     ppu.vram[0][0x1800] = 0x01;
     let mut if_reg = 0u8;
     ppu.step(456, &mut if_reg);
-    assert_eq!(ppu.framebuffer[0], 0x8BAC0FFF);
+    assert_eq!(ppu.framebuffer[0], 0x008BAC0F);
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn render_sprite_scanline() {
     ppu.oam[3] = 0; // flags
     let mut if_reg = 0u8;
     ppu.step(456, &mut if_reg);
-    assert_eq!(ppu.framebuffer[0], 0x8BAC0FFF);
+    assert_eq!(ppu.framebuffer[0], 0x008BAC0F);
 }
 
 #[test]
@@ -106,5 +106,5 @@ fn cgb_bg_palette() {
     ppu.vram[1][0x1800] = 0x02; // use palette 2
     let mut if_reg = 0u8;
     ppu.step(456, &mut if_reg);
-    assert_eq!(ppu.framebuffer[0], 0xFF0000FF);
+    assert_eq!(ppu.framebuffer[0], 0x00FF0000);
 }


### PR DESCRIPTION
## Summary
- store default DMG palette entries in 0x00RRGGBB format
- output CGB palette colors using the same packing
- update PPU tests for new color representation

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684d9d10ce248325acbe787eb468c7ea