### PR TITLE
Implement serial stub with link port trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod gameboy;
 pub mod input;
 pub mod mmu;
 pub mod ppu;
+pub mod serial;
 pub mod timer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod gameboy;
 mod input;
 mod mmu;
 mod ppu;
+mod serial;
 mod timer;
 
 use clap::Parser;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,0 +1,86 @@
+pub trait LinkPort {
+    /// Transfer a byte over the link. Returns the byte received from the
+    /// partner. Implementations may perform the transfer immediately.
+    fn transfer(&mut self, byte: u8) -> u8;
+}
+
+/// A stub link port used when no cable is attached.
+/// By default it emulates a "line dead" scenario where incoming bits are all 1,
+/// so any transfer receives 0xFF. When `loopback` is true the sent byte is
+/// echoed back instead.
+#[derive(Default)]
+pub struct NullLinkPort {
+    loopback: bool,
+}
+
+impl NullLinkPort {
+    pub fn new(loopback: bool) -> Self {
+        Self { loopback }
+    }
+}
+
+impl LinkPort for NullLinkPort {
+    fn transfer(&mut self, byte: u8) -> u8 {
+        if self.loopback { byte } else { 0xFF }
+    }
+}
+
+/// Represents the Game Boy serial registers.
+/// This struct handles SB/SC behavior and raises the serial interrupt
+/// when a transfer completes.
+pub struct Serial {
+    sb: u8,
+    sc: u8,
+    pub(crate) out_buf: Vec<u8>,
+    port: Box<dyn LinkPort>,
+}
+
+impl Serial {
+    pub fn new(cgb: bool) -> Self {
+        Self {
+            sb: 0,
+            sc: if cgb { 0x7F } else { 0x7E },
+            out_buf: Vec::new(),
+            port: Box::new(NullLinkPort::default()),
+        }
+    }
+
+    pub fn connect(&mut self, port: Box<dyn LinkPort>) {
+        self.port = port;
+    }
+
+    pub fn read(&self, addr: u16) -> u8 {
+        match addr {
+            0xFF01 => self.sb,
+            0xFF02 => self.sc,
+            _ => 0xFF,
+        }
+    }
+
+    pub fn write(&mut self, addr: u16, val: u8, if_reg: &mut u8) {
+        match addr {
+            0xFF01 => self.sb = val,
+            0xFF02 => {
+                self.sc = val;
+                if val & 0x80 != 0 {
+                    self.out_buf.push(self.sb);
+                    let received = self.port.transfer(self.sb);
+                    self.sb = received;
+                    self.sc &= 0x7F;
+                    *if_reg |= 0x08;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn take_output(&mut self) -> Vec<u8> {
+        let out = self.out_buf.clone();
+        self.out_buf.clear();
+        out
+    }
+
+    pub fn peek_output(&self) -> &[u8] {
+        &self.out_buf
+    }
+}

--- a/tests/cpu_instrs_rom.rs
+++ b/tests/cpu_instrs_rom.rs
@@ -7,7 +7,7 @@ fn run_cpu_instrs<P: AsRef<std::path::Path>>(rom_path: P, max_cycles: u64) -> St
 
     while gb.cpu.cycles < max_cycles {
         gb.cpu.step(&mut gb.mmu);
-        let out = String::from_utf8_lossy(&gb.mmu.serial_out);
+        let out = String::from_utf8_lossy(gb.mmu.serial.peek_output());
         if out.contains("Passed") || out.contains("Failed") {
             break;
         }

--- a/tests/instr_timing_rom.rs
+++ b/tests/instr_timing_rom.rs
@@ -7,7 +7,7 @@ fn run_instr_timing<P: AsRef<std::path::Path>>(rom_path: P, max_cycles: u64) -> 
 
     while gb.cpu.cycles < max_cycles {
         gb.cpu.step(&mut gb.mmu);
-        let out = String::from_utf8_lossy(&gb.mmu.serial_out);
+        let out = String::from_utf8_lossy(gb.mmu.serial.peek_output());
         if out.contains("Passed") || out.contains("Failed") {
             break;
         }

--- a/tests/mem_timing_rom.rs
+++ b/tests/mem_timing_rom.rs
@@ -7,7 +7,7 @@ fn run_mem_timing<P: AsRef<std::path::Path>>(rom_path: P, max_cycles: u64) -> St
 
     while gb.cpu.cycles < max_cycles {
         gb.cpu.step(&mut gb.mmu);
-        let out = String::from_utf8_lossy(&gb.mmu.serial_out);
+        let out = String::from_utf8_lossy(gb.mmu.serial.peek_output());
         if out.contains("Passed") || out.contains("Failed") {
             break;
         }


### PR DESCRIPTION
## Summary
- add Serial module with LinkPort trait and NullLinkPort stub
- move serial register logic from MMU to Serial
- expose serial buffer access and integrate with tests
- update main to include new module

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_684e108939ac8325a0e8577ff898c6f7