### PR TITLE
Add halt_bug screenshot test and ignore save files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+*.sav
+*.rtc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +563,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +667,25 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foreign-types"
@@ -949,6 +989,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,6 +1278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1506,6 +1560,19 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "polling"
@@ -1799,6 +1866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2132,7 @@ dependencies = [
  "clap",
  "cpal",
  "env_logger",
+ "image",
  "log",
  "minifb",
  "pixels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ path = "src/lib.rs"
 
 [dev-dependencies]
 tempfile = "3"
+image = { version = "0.24", default-features = false, features = ["png"] }

--- a/tests/halt_bug_rom.rs
+++ b/tests/halt_bug_rom.rs
@@ -1,0 +1,40 @@
+use image::io::Reader as ImageReader;
+use vibeEmu::{cartridge::Cartridge, gameboy::GameBoy};
+
+const DMG_PALETTE: [u32; 4] = [0x009BBC0F, 0x008BAC0F, 0x00306230, 0x000F380F];
+
+#[test]
+fn halt_bug_rom() {
+    let mut gb = GameBoy::new();
+    let rom = std::fs::read("roms/blargg/halt_bug.gb").expect("rom not found");
+    gb.mmu.load_cart(Cartridge::load(rom));
+
+    let mut frames = 0u32;
+    while frames < 120 {
+        gb.cpu.step(&mut gb.mmu);
+        if gb.mmu.ppu.frame_ready() {
+            gb.mmu.ppu.clear_frame_flag();
+            frames += 1;
+        }
+    }
+
+    let expected = ImageReader::open("roms/blargg/halt_bug-dmg-cgb.png")
+        .unwrap()
+        .decode()
+        .unwrap()
+        .to_rgb8();
+    assert_eq!(expected.width(), 160);
+    assert_eq!(expected.height(), 144);
+
+    let frame = gb.mmu.ppu.framebuffer();
+    for (idx, pixel) in expected.pixels().enumerate() {
+        let expected_color = match pixel.0 {
+            [0x00, 0x00, 0x00] => DMG_PALETTE[3],
+            [0x55, 0x55, 0x55] => DMG_PALETTE[2],
+            [0xAA, 0xAA, 0xAA] => DMG_PALETTE[1],
+            [0xFF, 0xFF, 0xFF] => DMG_PALETTE[0],
+            _ => panic!("unexpected color {:?}", pixel),
+        };
+        assert_eq!(frame[idx], expected_color, "pixel mismatch at index {idx}");
+    }
+}


### PR DESCRIPTION
## Summary
- ignore `.sav` and `.rtc` files in Git
- add the `image` crate for tests
- verify `halt_bug.gb` by comparing the framebuffer to the reference image

## Testing
- `cargo clippy`
- `cargo test --test halt_bug_rom -- --nocapture`
- `cargo test`
- `cargo test --release`

------
https://chatgpt.com/codex/tasks/task_e_684e168198cc8325847c3ca1f0ea0cf7