### PR TITLE
Add CI workflow for Linux and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev libx11-dev
+
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Lint
+        run: cargo clippy -- -D warnings
+
+      - name: Test debug
+        run: cargo test --verbose
+
+      - name: Test release
+        run: cargo test --release --verbose

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ cargo build
 ```
 
 The frontend uses the `minifb` crate for window creation. On Linux you may need
-X11 development packages installed (e.g. `libx11-dev`).
+X11 development packages installed (e.g. `libx11-dev`). Audio output relies on
+`cpal`, which requires ALSA headers. Install `libasound2-dev` as well if you
+build on Linux.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- run formatting, linting and tests in CI
- install Linux audio deps and document them

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`
- `cargo test --release --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684e1a8ef7f083259b23ca2d8e683430