### PR TITLE
Connect APU to audio output

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -490,7 +490,7 @@ impl Cpu {
             self.cycles += 4;
             mmu.timer.step(4, &mut mmu.if_reg);
             mmu.ppu.step(4, &mut mmu.if_reg);
-            mmu.apu.step(4);
+            mmu.apu.lock().unwrap().step(4);
             self.handle_interrupts(mmu);
             return;
         }
@@ -1491,7 +1491,7 @@ impl Cpu {
         self.cycles += cycles as u64;
         mmu.timer.step(cycles, &mut mmu.if_reg);
         mmu.ppu.step(cycles, &mut mmu.if_reg);
-        mmu.apu.step(cycles);
+        mmu.apu.lock().unwrap().step(cycles);
 
         if enable_after {
             self.ime = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod timer;
 use clap::Parser;
 use log::info;
 use minifb::{Key, Scale, Window, WindowOptions};
+use std::sync::Arc;
 use std::time::Duration;
 
 #[derive(Parser)]
@@ -78,6 +79,8 @@ fn main() {
         "Emulator initialized in {} mode",
         if cgb_mode { "CGB" } else { "DMG" }
     );
+
+    let _stream = apu::Apu::start_stream(Arc::clone(&gb.mmu.apu));
 
     let mut frame = vec![0u32; 160 * 144];
     let mut frame_count = 0u64;


### PR DESCRIPTION
## Summary
- keep APU in an `Arc<Mutex<>>` so it can be shared
- start the cpal audio stream when the emulator launches
- update CPU and MMU to lock the shared APU when stepping or reading/writing registers

## Testing
- `cargo fmt --all`
- `cargo clippy -q`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_684e1fac0aec8325af5d5f52b3421bb3