### PR TITLE
Implement DMA timing and STAT IRQ edge handling

### DIFF
--- a/tests/mmu.rs
+++ b/tests/mmu.rs
@@ -111,6 +111,7 @@ fn oam_dma_transfer() {
         mmu.write_byte(0x8000 + i, i as u8);
     }
     mmu.write_byte(0xFF46, 0x80); // copy from 0x8000
+    mmu.dma_step(640);
     assert_eq!(mmu.ppu.oam[0], 0x00);
     assert_eq!(mmu.ppu.oam[0x9F], 0x9F);
 }


### PR DESCRIPTION
## Summary
- implement DMA stepper in `Mmu` that stalls CPU via `Cpu::step`
- block CPU during DMA copy cycles
- track STAT interrupt sources and trigger only on edges
- update unit test for DMA timing

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e42ec4c808325a4d7b63c6392070b