### PR TITLE
Implement palette auto-increment on read

### DIFF
--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -164,9 +164,21 @@ impl Ppu {
             0xFF4A => self.wy,
             0xFF4B => self.wx,
             0xFF68 => self.bgpi,
-            0xFF69 => self.bgpd[(self.bgpi & 0x3F) as usize],
+            0xFF69 => {
+                let val = self.bgpd[(self.bgpi & 0x3F) as usize];
+                if self.bgpi & 0x80 != 0 {
+                    self.bgpi = (self.bgpi & 0x80) | ((self.bgpi.wrapping_add(1)) & 0x3F);
+                }
+                val
+            }
             0xFF6A => self.obpi,
-            0xFF6B => self.obpd[(self.obpi & 0x3F) as usize],
+            0xFF6B => {
+                let val = self.obpd[(self.obpi & 0x3F) as usize];
+                if self.obpi & 0x80 != 0 {
+                    self.obpi = (self.obpi & 0x80) | ((self.obpi.wrapping_add(1)) & 0x3F);
+                }
+                val
+            }
             _ => 0xFF,
         }
     }

--- a/tests/ppu.rs
+++ b/tests/ppu.rs
@@ -232,3 +232,33 @@ fn cgb_bg_bank_select() {
     ppu.step(456, &mut if_reg);
     assert_eq!(ppu.framebuffer[0], 0x00FF0000);
 }
+
+#[test]
+fn cgb_obj_palette_autoinc_read() {
+    let mut ppu = Ppu::new_with_mode(true);
+    // write two values with auto-increment
+    ppu.write_reg(0xFF6A, 0x80); // index 0, auto inc
+    ppu.write_reg(0xFF6B, 0x11);
+    ppu.write_reg(0xFF6B, 0x22);
+
+    // read back with auto-increment
+    ppu.write_reg(0xFF6A, 0x80); // index 0, auto inc
+    assert_eq!(ppu.read_reg(0xFF6B), 0x11);
+    assert_eq!(ppu.read_reg(0xFF6A) & 0x3F, 1);
+    assert_eq!(ppu.read_reg(0xFF6B), 0x22);
+    assert_eq!(ppu.read_reg(0xFF6A) & 0x3F, 2);
+}
+
+#[test]
+fn cgb_bg_palette_autoinc_read() {
+    let mut ppu = Ppu::new_with_mode(true);
+    ppu.write_reg(0xFF68, 0x80); // index 0, auto inc
+    ppu.write_reg(0xFF69, 0x33);
+    ppu.write_reg(0xFF69, 0x44);
+
+    ppu.write_reg(0xFF68, 0x80); // index 0, auto inc
+    assert_eq!(ppu.read_reg(0xFF69), 0x33);
+    assert_eq!(ppu.read_reg(0xFF68) & 0x3F, 1);
+    assert_eq!(ppu.read_reg(0xFF69), 0x44);
+    assert_eq!(ppu.read_reg(0xFF68) & 0x3F, 2);
+}


### PR DESCRIPTION
## Summary
- handle auto-increment when reading OBJ/BG palette data
- test CGB palette index auto-increment on reads

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_684e4597085c8325957c2c84eca1e7cd