### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/vulcandth/vibeEmu/security/code-scanning/1](https://github.com/vulcandth/vibeEmu/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow does not require write access to the repository.

**Steps to implement the fix:**
1. Add a `permissions` block at the root level of the workflow file.
2. Set `contents: read` to limit the `GITHUB_TOKEN` permissions to read-only access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
