### PR TITLE
Implement DMG compatibility default palettes

### DIFF
--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -59,7 +59,11 @@ impl Mmu {
     }
 
     pub fn load_cart(&mut self, cart: Cartridge) {
+        let is_dmg = !cart.cgb;
         self.cart = Some(cart);
+        if self.cgb_mode && is_dmg {
+            self.ppu.apply_dmg_compatibility_palettes();
+        }
     }
 
     pub fn save_cart_ram(&self) {


### PR DESCRIPTION
## Summary
- load default CGB palettes when running DMG ROMs
- set OBJ/BG palettes to match the CGB boot ROM behaviour

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_684ee047de548325b7e03bfb07e36900