### PR TITLE
CPU opcode ordering cleanup

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -928,6 +928,11 @@ impl Cpu {
                 self.a ^= val;
                 self.f = if self.a == 0 { 0x80 } else { 0 };
             }
+            0xAF => {
+                self.a ^= self.a;
+                // XOR A resets NF, HF, CF and sets Z
+                self.f = 0x80;
+            }
             opcode @ 0xB0..=0xB7 => {
                 let src = opcode & 0x07;
                 let val = match src {
@@ -966,11 +971,6 @@ impl Cpu {
                         0
                     }
                     | if self.a < val { 0x10 } else { 0 };
-            }
-            0xAF => {
-                self.a ^= self.a;
-                // XOR A resets NF, HF, CF and sets Z
-                self.f = 0x80;
             }
             0xC0 => {
                 if self.f & 0x80 == 0 {


### PR DESCRIPTION
## Summary
- reorder opcode match arms closer to ascending order
- remove outdated timing comment
- further reorder opcodes for consistency

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_68512652bb6083258970b8b72dad51c1