### PR TITLE
Implement post-boot hardware register defaults

### DIFF
--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -26,8 +26,7 @@ pub struct Mmu {
 
 impl Mmu {
     pub fn new_with_mode(cgb: bool) -> Self {
-        let mut timer = Timer::new();
-        timer.div = 0xAB00;
+        let timer = Timer::post_boot_defaults();
 
         let mut ppu = Ppu::new_with_mode(cgb);
         ppu.apply_boot_state();
@@ -47,7 +46,7 @@ impl Mmu {
             timer,
             input: Input::new(),
             key1: if cgb { 0x7E } else { 0 },
-            rp: 0,
+            rp: if cgb { 0x3E } else { 0 },
             dma_cycles: 0,
             dma_source: 0,
             cgb_mode: cgb,
@@ -122,13 +121,30 @@ impl Mmu {
             }
             0xFF56 => {
                 if self.cgb_mode {
-                    self.rp | 0xC0
+                    self.rp
                 } else {
                     0xFF
                 }
             }
-            0xFF4F => self.ppu.vram_bank as u8,
-            0xFF70 => self.wram_bank as u8,
+            0xFF4F => {
+                if self.cgb_mode {
+                    0xFE | (self.ppu.vram_bank as u8 & 0x01)
+                } else {
+                    0xFF
+                }
+            }
+            0xFF70 => {
+                if self.cgb_mode {
+                    let bank_bits = if self.wram_bank == 1 {
+                        0
+                    } else {
+                        self.wram_bank as u8 & 0x07
+                    };
+                    0xF8 | bank_bits
+                } else {
+                    0xFF
+                }
+            }
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
             0xFFFF => self.ie_reg,
             _ => 0xFF,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -21,6 +21,20 @@ impl Timer {
         }
     }
 
+    /// Create a timer initialized to the register state normally
+    /// observed after the boot ROM has finished executing. This is
+    /// used when starting the emulator without running a boot ROM so
+    /// hardware defaults are respected.
+    pub fn post_boot_defaults() -> Self {
+        Self {
+            div: 0xAB00,
+            tima: 0,
+            tma: 0,
+            tac: 0,
+            last_signal: false,
+        }
+    }
+
     pub fn read(&self, addr: u16) -> u8 {
         match addr {
             0xFF04 => (self.div >> 8) as u8,

--- a/tests/mmu.rs
+++ b/tests/mmu.rs
@@ -133,3 +133,22 @@ fn vram_oam_access_blocking() {
     mmu.write_byte(0xFE00, 0x56);
     assert_eq!(mmu.read_byte(0xFE00), 0x56);
 }
+#[test]
+fn hardware_register_defaults() {
+    let mut mmu_dmg = Mmu::new();
+    assert_eq!(mmu_dmg.read_byte(0xFF4F), 0xFF);
+    assert_eq!(mmu_dmg.read_byte(0xFF70), 0xFF);
+    assert_eq!(mmu_dmg.read_byte(0xFF04), 0xAB);
+    assert_eq!(mmu_dmg.read_byte(0xFF05), 0x00);
+    assert_eq!(mmu_dmg.read_byte(0xFF06), 0x00);
+    assert_eq!(mmu_dmg.read_byte(0xFF07), 0xF8);
+
+    let mut mmu_cgb = Mmu::new_with_mode(true);
+    assert_eq!(mmu_cgb.read_byte(0xFF4F), 0xFE);
+    assert_eq!(mmu_cgb.read_byte(0xFF70), 0xF8);
+    assert_eq!(mmu_cgb.read_byte(0xFF56), 0x3E);
+    assert_eq!(mmu_cgb.read_byte(0xFF04), 0xAB);
+    assert_eq!(mmu_cgb.read_byte(0xFF05), 0x00);
+    assert_eq!(mmu_cgb.read_byte(0xFF06), 0x00);
+    assert_eq!(mmu_cgb.read_byte(0xFF07), 0xF8);
+}


### PR DESCRIPTION
## Summary
- emulate hardware defaults when skipping the boot ROM
- test default CGB registers
- add timer post-boot setup

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`
- `cargo test --release --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68512a9164308325b3d5d5e33965ba5f