### PR TITLE
feat(dma): implement GDMA & HDMA support

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -98,7 +98,11 @@ impl Cpu {
         let hw_cycles = if self.double_speed { 2 } else { 4 } * m_cycles as u16;
         self.cycles += hw_cycles as u64;
         mmu.timer.step(hw_cycles, &mut mmu.if_reg);
+        let prev_mode = mmu.ppu.mode;
         mmu.ppu.step(hw_cycles, &mut mmu.if_reg);
+        if prev_mode != 0 && mmu.ppu.mode == 0 {
+            mmu.on_hblank();
+        }
         mmu.apu.lock().unwrap().step(hw_cycles);
     }
 
@@ -328,6 +332,11 @@ impl Cpu {
     pub fn step(&mut self, mmu: &mut crate::mmu::Mmu) {
         if mmu.dma_active() {
             mmu.dma_step(4);
+            self.tick(mmu, 1);
+            return;
+        }
+        if mmu.cgb_dma_active() {
+            mmu.cgb_dma_step(4);
             self.tick(mmu, 1);
             return;
         }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -147,7 +147,7 @@ impl Mmu {
             0xFF55 => match self.dma_state {
                 DmaState::Idle => 0xFF,
                 DmaState::Gdma { blocks_left, .. } | DmaState::Hdma { blocks_left, .. } => {
-                    (blocks_left.wrapping_sub(1) & 0x7F)
+                    blocks_left.wrapping_sub(1) & 0x7F
                 }
             },
             0xFF4D => {
@@ -327,10 +327,8 @@ impl Mmu {
                 self.hdma5 = remaining.wrapping_sub(1);
                 *blocks_left = remaining;
             }
-        } else if self.dma_busy == 0 {
-            if matches!(self.dma_state, DmaState::Hdma { .. }) {
-                // HDMA block finished; nothing to update here
-            }
+        } else if self.dma_busy == 0 && matches!(self.dma_state, DmaState::Hdma { .. }) {
+            // HDMA block finished; nothing to update here
         }
     }
 
@@ -394,7 +392,7 @@ impl Mmu {
                 s = s.wrapping_add(1);
                 d = d.wrapping_add(1);
             }
-            let mut left = blocks_left - 1;
+            let left = blocks_left - 1;
             self.dma_busy = 32;
             if self.hdma_stop || left == 0 {
                 self.dma_state = DmaState::Idle;

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -3,6 +3,13 @@ use std::sync::{Arc, Mutex};
 
 const WRAM_BANK_SIZE: usize = 0x1000;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DmaState {
+    Idle,
+    Gdma { blocks_left: u8, cycles_left: u32 },
+    Hdma { src: u16, dst: u16, blocks_left: u8 },
+}
+
 pub struct Mmu {
     pub wram: [[u8; WRAM_BANK_SIZE]; 8],
     pub wram_bank: usize,
@@ -23,6 +30,14 @@ pub struct Mmu {
     dma_source: u16,
     pending_dma: Option<u16>,
     pending_delay: u16,
+    hdma1: u8,
+    hdma2: u8,
+    hdma3: u8,
+    hdma4: u8,
+    hdma5: u8,
+    dma_state: DmaState,
+    dma_busy: u32,
+    hdma_stop: bool,
     cgb_mode: bool,
 }
 
@@ -54,6 +69,14 @@ impl Mmu {
             dma_source: 0,
             pending_dma: None,
             pending_delay: 0,
+            hdma1: 0,
+            hdma2: 0,
+            hdma3: 0,
+            hdma4: 0,
+            hdma5: 0xFF,
+            dma_state: DmaState::Idle,
+            dma_busy: 0,
+            hdma_stop: false,
             cgb_mode: cgb,
         }
     }
@@ -117,6 +140,16 @@ impl Mmu {
             0xFF0F => self.if_reg,
             0xFF10..=0xFF3F => self.apu.lock().unwrap().read_reg(addr),
             0xFF40..=0xFF4B | 0xFF68..=0xFF6B => self.ppu.read_reg(addr),
+            0xFF51 => self.hdma1 & 0xF0,
+            0xFF52 => self.hdma2 & 0xF0,
+            0xFF53 => self.hdma3 & 0xF0,
+            0xFF54 => self.hdma4 & 0xF0,
+            0xFF55 => match self.dma_state {
+                DmaState::Idle => 0xFF,
+                DmaState::Gdma { blocks_left, .. } | DmaState::Hdma { blocks_left, .. } => {
+                    (blocks_left.wrapping_sub(1) & 0x7F)
+                }
+            },
             0xFF4D => {
                 if self.cgb_mode {
                     (self.key1 & 0x81) | 0x7E
@@ -167,6 +200,27 @@ impl Mmu {
             0xFF0F => self.if_reg = (val & 0x1F) | (self.if_reg & 0xE0),
             0xFF10..=0xFF3F => self.apu.lock().unwrap().write_reg(addr, val),
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B | 0xFF68..=0xFF6B => self.ppu.write_reg(addr, val),
+            0xFF51 => {
+                if matches!(self.dma_state, DmaState::Idle) {
+                    self.hdma1 = val;
+                }
+            }
+            0xFF52 => {
+                if matches!(self.dma_state, DmaState::Idle) {
+                    self.hdma2 = val;
+                }
+            }
+            0xFF53 => {
+                if matches!(self.dma_state, DmaState::Idle) {
+                    self.hdma3 = val;
+                }
+            }
+            0xFF54 => {
+                if matches!(self.dma_state, DmaState::Idle) {
+                    self.hdma4 = val;
+                }
+            }
+            0xFF55 => self.handle_hdma_write(val),
             0xFF4D => {
                 if self.cgb_mode {
                     self.key1 = (self.key1 & 0x80) | (val & 0x01);
@@ -239,6 +293,122 @@ impl Mmu {
     /// Return true if a DMA transfer is in progress.
     pub fn dma_active(&self) -> bool {
         self.dma_cycles > 0 || self.pending_delay > 0
+    }
+
+    /// Return true if a CGB DMA (GDMA/HDMA) burst is stalling the CPU.
+    pub fn cgb_dma_active(&self) -> bool {
+        self.dma_busy > 0
+    }
+
+    /// Advance timing for the active GDMA or HDMA burst.
+    pub fn cgb_dma_step(&mut self, cycles: u16) {
+        if self.dma_busy >= cycles as u32 {
+            self.dma_busy -= cycles as u32;
+        } else {
+            self.dma_busy = 0;
+        }
+        if let DmaState::Gdma {
+            ref mut cycles_left,
+            ref mut blocks_left,
+        } = self.dma_state
+        {
+            if *cycles_left >= cycles as u32 {
+                *cycles_left -= cycles as u32;
+            } else {
+                *cycles_left = 0;
+            }
+            let completed_blocks =
+                (blocks_left.wrapping_mul(32) as u32).saturating_sub(*cycles_left) / 32;
+            let remaining = blocks_left.saturating_sub(completed_blocks as u8);
+            if remaining == 0 && *cycles_left == 0 {
+                self.dma_state = DmaState::Idle;
+                self.hdma5 = 0xFF;
+            } else {
+                self.hdma5 = remaining.wrapping_sub(1);
+                *blocks_left = remaining;
+            }
+        } else if self.dma_busy == 0 {
+            if matches!(self.dma_state, DmaState::Hdma { .. }) {
+                // HDMA block finished; nothing to update here
+            }
+        }
+    }
+
+    fn handle_hdma_write(&mut self, val: u8) {
+        match self.dma_state {
+            DmaState::Hdma { .. } => {
+                if val & 0x80 == 0 {
+                    // manual stop
+                    self.hdma_stop = true;
+                    self.hdma5 = 0x7F;
+                }
+            }
+            DmaState::Gdma { .. } => {}
+            DmaState::Idle => {
+                let blocks = (val & 0x7F).wrapping_add(1);
+                let src = ((self.hdma1 as u16) << 8) | (self.hdma2 as u16 & 0xF0);
+                let dst = 0x8000 | (((self.hdma3 as u16) << 8) | (self.hdma4 as u16 & 0xF0));
+
+                if val & 0x80 == 0 {
+                    // GDMA
+                    for i in 0..(blocks as u16 * 0x10) {
+                        let b = self.read_byte(src.wrapping_add(i));
+                        let addr = dst.wrapping_add(i).wrapping_sub(0x8000);
+                        self.ppu.vram[self.ppu.vram_bank][(addr & 0x1FFF) as usize] = b;
+                    }
+                    self.dma_state = DmaState::Gdma {
+                        blocks_left: blocks,
+                        cycles_left: blocks as u32 * 32,
+                    };
+                    self.dma_busy = blocks as u32 * 32;
+                    self.hdma5 = blocks.wrapping_sub(1);
+                } else {
+                    // HDMA
+                    self.dma_state = DmaState::Hdma {
+                        src,
+                        dst,
+                        blocks_left: blocks,
+                    };
+                    self.hdma5 = blocks.wrapping_sub(1);
+                }
+            }
+        }
+    }
+
+    /// Called at the start of each H-Blank period.
+    pub fn on_hblank(&mut self) {
+        if let DmaState::Hdma {
+            src,
+            dst,
+            blocks_left,
+        } = self.dma_state
+        {
+            if blocks_left == 0 {
+                return;
+            }
+            let mut s = src;
+            let mut d = dst;
+            for _ in 0..16 {
+                let b = self.read_byte(s);
+                self.ppu.vram[self.ppu.vram_bank][((d - 0x8000) & 0x1FFF) as usize] = b;
+                s = s.wrapping_add(1);
+                d = d.wrapping_add(1);
+            }
+            let mut left = blocks_left - 1;
+            self.dma_busy = 32;
+            if self.hdma_stop || left == 0 {
+                self.dma_state = DmaState::Idle;
+                self.hdma5 = 0xFF;
+                self.hdma_stop = false;
+            } else {
+                self.dma_state = DmaState::Hdma {
+                    src: s,
+                    dst: d,
+                    blocks_left: left,
+                };
+                self.hdma5 = left - 1;
+            }
+        }
     }
 }
 

--- a/tests/dma.rs
+++ b/tests/dma.rs
@@ -1,0 +1,40 @@
+use vibeEmu::mmu::Mmu;
+
+#[test]
+fn gdma_transfer() {
+    let mut mmu = Mmu::new_with_mode(true);
+    for i in 0..16u16 {
+        mmu.write_byte(0xC000 + i, i as u8);
+    }
+    mmu.write_byte(0xFF51, 0xC0);
+    mmu.write_byte(0xFF52, 0x00);
+    mmu.write_byte(0xFF53, 0x80);
+    mmu.write_byte(0xFF54, 0x00);
+    mmu.write_byte(0xFF55, 0x00); // length 0 -> 1 block GDMA
+    mmu.cgb_dma_step(32);
+    for i in 0..16u16 {
+        assert_eq!(mmu.ppu.vram[0][i as usize], i as u8);
+    }
+    assert_eq!(mmu.read_byte(0xFF55), 0xFF);
+}
+
+#[test]
+fn hdma_stop_after_first_block() {
+    let mut mmu = Mmu::new_with_mode(true);
+    for i in 0..32u16 {
+        mmu.write_byte(0xC000 + i, i as u8);
+    }
+    mmu.write_byte(0xFF51, 0xC0);
+    mmu.write_byte(0xFF52, 0x00);
+    mmu.write_byte(0xFF53, 0x80);
+    mmu.write_byte(0xFF54, 0x00);
+    mmu.write_byte(0xFF55, 0x81); // 2 blocks HDMA
+    mmu.write_byte(0xFF55, 0x00); // stop after current block
+    mmu.on_hblank();
+    mmu.cgb_dma_step(32);
+    for i in 0..16u16 {
+        assert_eq!(mmu.ppu.vram[0][i as usize], i as u8);
+    }
+    assert_eq!(mmu.ppu.vram[0][16], 0);
+    assert_eq!(mmu.read_byte(0xFF55), 0xFF);
+}


### PR DESCRIPTION
## Summary
- implement cycle-accurate GDMA and HDMA logic inside `Mmu`
- update CPU to trigger HDMA on hblank and stall during DMA
- add unit tests for both GDMA and HDMA

No new dependencies were added. Use `cargo test` to run the full test suite.


------
https://chatgpt.com/codex/tasks/task_e_6851f58564fc8325a51114470c4e453e