### PR TITLE
Add CGB HDMA/GDMA implementation

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -98,7 +98,9 @@ impl Cpu {
         let hw_cycles = if self.double_speed { 2 } else { 4 } * m_cycles as u16;
         self.cycles += hw_cycles as u64;
         mmu.timer.step(hw_cycles, &mut mmu.if_reg);
-        mmu.ppu.step(hw_cycles, &mut mmu.if_reg);
+        if mmu.ppu.step(hw_cycles, &mut mmu.if_reg) {
+            mmu.hdma_hblank_transfer();
+        }
         mmu.apu.lock().unwrap().step(hw_cycles);
     }
 

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -153,11 +153,11 @@ impl Mmu {
             0xFF53 => ((self.hdma.dst & 0x1F00) >> 8) as u8,
             0xFF54 => (self.hdma.dst & 0x00F0) as u8,
             0xFF55 => {
-                let mut status = self.hdma.blocks.saturating_sub(1);
                 if self.hdma.active {
-                    status |= 0x80;
+                    (self.hdma.blocks.saturating_sub(1)) | 0x80
+                } else {
+                    0xFF
                 }
-                status
             }
             0xFF4D => {
                 if self.cgb_mode {

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -489,8 +489,9 @@ impl Ppu {
         }
     }
 
-    pub fn step(&mut self, cycles: u16, if_reg: &mut u8) {
+    pub fn step(&mut self, cycles: u16, if_reg: &mut u8) -> bool {
         let mut remaining = cycles;
+        let mut hblank_triggered = false;
         while remaining > 0 {
             let increment = remaining.min(4);
             remaining -= increment;
@@ -551,6 +552,7 @@ impl Ppu {
                         self.mode_clock -= 172;
                         self.render_scanline();
                         self.mode = 0;
+                        hblank_triggered = true;
                         if self.stat & 0x08 != 0 {
                             *if_reg |= 0x02;
                         }
@@ -561,6 +563,7 @@ impl Ppu {
 
             self.update_stat_irq(if_reg);
         }
+        hblank_triggered
     }
 
     fn update_stat_irq(&mut self, if_reg: &mut u8) {


### PR DESCRIPTION
## Summary
- implement DMA mode and state for HDMA/GDMA transfers
- expose CGB DMA registers and add immediate/HDMA copy helpers
- return HBlank information from PPU step
- trigger HDMA on HBlank in CPU tick

## Testing
- `cargo fmt --all`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68520daedc008325b7192e716199de1d