### PR TITLE
Fix HDMA register handling and DMA timing

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -334,6 +334,12 @@ impl Cpu {
             return;
         }
 
+        if mmu.gdma_active() {
+            mmu.gdma_step(1);
+            self.tick(mmu, 1);
+            return;
+        }
+
         if self.halted {
             self.tick(mmu, 1);
             self.handle_interrupts(mmu);


### PR DESCRIPTION
## Summary
- correct FF55 HDMA abort logic
- update DMA address registers during GDMA and HDMA
- stall CPU during General/HBlank DMA transfers
- bypass VRAM mode checks for DMA writes

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68521f49cab083259dff45ef589aaf45