### PR TITLE
tests: silence remaining clippy warnings

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -29,6 +29,7 @@ pub fn roms_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("test_roms")
 }
 
+#[allow(dead_code)]
 pub fn rom_path<P: AsRef<Path>>(relative: P) -> PathBuf {
     roms_dir().join(relative)
 }

--- a/tests/mooneye_acceptance.rs
+++ b/tests/mooneye_acceptance.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 mod common;
 use vibeEmu::{cartridge::Cartridge, gameboy::GameBoy};
 const FIB_SEQ: [u8; 6] = [3, 5, 8, 13, 21, 34];
@@ -12,7 +13,7 @@ fn run_mooneye_acceptance<P: AsRef<std::path::Path>>(rom_path: P, max_cycles: u6
         }
     }
     let out = gb.mmu.serial.take_output();
-    out.len() >= 6 && &out[0..6] == FIB_SEQ
+    out.len() >= 6 && out[0..6] == FIB_SEQ
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- silence op_ref lint in acceptance tests
- suppress dead_code for `rom_path` helper

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_68531b9aa8fc8325848e75fcaef3b3f3