### PR TITLE
Fix OAM DMA start timing

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -149,6 +149,7 @@ impl Cpu {
             mmu.hdma_hblank_transfer();
         }
         mmu.apu.lock().unwrap().step(hw_cycles);
+        mmu.dma_step(hw_cycles);
     }
 
     #[inline(always)]
@@ -383,12 +384,6 @@ impl Cpu {
     }
 
     pub fn step(&mut self, mmu: &mut crate::mmu::Mmu) {
-        if mmu.dma_active() {
-            mmu.dma_step(OAM_DMA_STEP_CYCLES.into());
-            self.tick(mmu, 1);
-            return;
-        }
-
         if mmu.gdma_active() {
             mmu.gdma_step(GDMA_STEP_CYCLES.into());
             self.tick(mmu, 1);

--- a/tests/mooneye_acceptance.rs
+++ b/tests/mooneye_acceptance.rs
@@ -391,7 +391,6 @@ fn oam_dma_restart_gb() {
 }
 
 #[test]
-#[ignore]
 fn oam_dma_start_gb() {
     let passed = run_mooneye_acceptance(
         common::rom_path("mooneye-test-suite/acceptance/oam_dma_start.gb"),


### PR DESCRIPTION
## Summary
- implement concurrent DMA stepping instead of stalling the CPU
- enforce DMA transfer delay and open bus behaviour in MMU
- allow reading DMA register while DMA is active
- unignore and pass mooneye `oam_dma_start` test

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_685370013fc88325a5e5510296afe073