### PR TITLE
Integrate ImGui rendering via pixels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libx11-dev
+          sudo apt-get install -y libasound2-dev libx11-dev build-essential pkg-config libfontconfig1-dev
 
       - name: Cache rustup (optional)
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sav
 *.rtc
 test_roms/
+imgui.ini

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ clap = { version = "4", features = ["derive"] }
 winit = "0.27.5"
 wgpu = "0.17"
 pixels = "0.14"
-imgui = "0.11"
+imgui = { version = "0.11", features = ["docking"] }
 imgui-winit-support = "0.11"
 imgui-wgpu = "0.24"
 cpal = "0.15"

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,9 +280,10 @@ fn main() {
                     build_ui(&mut ui_state, ui);
                     platform.prepare_render(ui, &window);
 
-                    pixels
-                        .frame_mut()
-                        .copy_from_slice(bytemuck::cast_slice(&frame));
+                    let pixel_frame: &mut [u32] = bytemuck::cast_slice_mut(pixels.frame_mut());
+                    for (dst, src) in pixel_frame.iter_mut().zip(&frame) {
+                        *dst = 0xFF00_0000 | *src;
+                    }
                     let draw_data = imgui.render();
                     let render_result = pixels.render_with(|encoder, render_target, context| {
                         context.scaling_renderer.render(encoder, render_target);

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,10 @@ fn main() {
 
                     let pixel_frame: &mut [u32] = bytemuck::cast_slice_mut(pixels.frame_mut());
                     for (dst, src) in pixel_frame.iter_mut().zip(&frame) {
-                        *dst = 0xFF00_0000 | *src;
+                        let r = ((src >> 16) & 0xFF) as u8;
+                        let g = ((src >> 8) & 0xFF) as u8;
+                        let b = (src & 0xFF) as u8;
+                        *dst = u32::from_ne_bytes([r, g, b, 0xFF]);
                     }
                     let draw_data = imgui.render();
                     let render_result = pixels.render_with(|encoder, render_target, context| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,22 +277,26 @@ fn main() {
                     pixels
                         .frame_mut()
                         .copy_from_slice(bytemuck::cast_slice(&frame));
+                    let draw_data = imgui.render();
                     let render_result = pixels.render_with(|encoder, render_target, _| {
-                        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                            label: Some("imgui_pass"),
-                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                view: render_target,
-                                resolve_target: None,
-                                ops: wgpu::Operations {
-                                    load: wgpu::LoadOp::Load,
-                                    store: true,
-                                },
-                            })],
-                            depth_stencil_attachment: None,
-                        });
-                        renderer
-                            .render(imgui.render(), pixels.queue(), pixels.device(), &mut rpass)
-                            .expect("imgui render failed");
+                        if draw_data.total_vtx_count > 0 {
+                            let mut rpass =
+                                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                    label: Some("imgui_pass"),
+                                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                        view: render_target,
+                                        resolve_target: None,
+                                        ops: wgpu::Operations {
+                                            load: wgpu::LoadOp::Load,
+                                            store: true,
+                                        },
+                                    })],
+                                    depth_stencil_attachment: None,
+                                });
+                            renderer
+                                .render(draw_data, pixels.queue(), pixels.device(), &mut rpass)
+                                .expect("imgui render failed");
+                        }
                         Ok(())
                     });
                     if render_result.is_err() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
     let _stream = if args.headless {
         None
     } else {
-        Some(apu::Apu::start_stream(Arc::clone(&gb.mmu.apu)))
+        apu::Apu::start_stream(Arc::clone(&gb.mmu.apu))
     };
 
     let mut frame = vec![0u32; 160 * 144];


### PR DESCRIPTION
## Summary
- set up imgui context and wgpu renderer
- hook imgui into the window event loop
- render imgui overlay using `pixels.render_with`
- enable imgui `docking` feature

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`

------
https://chatgpt.com/codex/tasks/task_e_68554fc399bc8325a788d7a13516d787