### PR TITLE
Option B: free d-pad when not typing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -340,7 +340,8 @@ fn main() {
                         }
                     }
                     WindowEvent::KeyboardInput { input, .. } => {
-                        if !imgui.io().want_capture_keyboard {
+                        // Allow arrows unless we're paused or actively typing in ImGui
+                        if !(ui_state.paused || imgui.io().want_text_input) {
                             if let Some(key) = input.virtual_keycode {
                                 let pressed = input.state == ElementState::Pressed;
                                 let mask = match key {


### PR DESCRIPTION
## Summary
- adjust keyboard handling to ignore `want_capture_keyboard` when not paused and not entering text

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_6855beffe8cc83259c5ccb6dcab343ad