### PR TITLE
Ensure left-click hides context menu

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -395,7 +395,11 @@ fn main() {
                                 button: MouseButton::Left,
                                 ..
                             } if matches!(win.kind, WindowKind::Main) => {
-                                ui_state.paused = false;
+                                if cursor_in_screen(&win.win, cursor_pos) {
+                                    // Always resume emulation and close the contextual menu on left-click
+                                    ui_state.paused = false;
+                                    ui_state.show_context = false;
+                                }
                             }
                             WindowEvent::KeyboardInput { input, .. }
                                 if matches!(win.kind, WindowKind::Main) =>

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,12 @@ fn main() {
                 } => {
                     if let Some(win) = windows.get_mut(window_id) {
                         platform.handle_event(imgui.io_mut(), &win.win, &event);
+                        if ui_state.show_context
+                            && imgui.io().want_capture_mouse
+                            && matches!(win_event, WindowEvent::MouseInput { .. })
+                        {
+                            return;
+                        }
                         match win_event {
                             WindowEvent::CloseRequested => {
                                 windows.remove(window_id);
@@ -395,8 +401,12 @@ fn main() {
                                 button: MouseButton::Left,
                                 ..
                             } if matches!(win.kind, WindowKind::Main) => {
-                                if cursor_in_screen(&win.win, cursor_pos) {
-                                    // Always resume emulation and close the contextual menu on left-click
+                                // If the context menu is open and ImGui wants the mouse,
+                                // let the menu handle the click without closing it.
+                                if ui_state.show_context && imgui.io().want_capture_mouse {
+                                    // Menu click: handled by ImGui.
+                                } else if cursor_in_screen(&win.win, cursor_pos) {
+                                    // Clicking the bare Game Boy screen closes the menu and resumes.
                                     ui_state.paused = false;
                                     ui_state.show_context = false;
                                 }


### PR DESCRIPTION
## Summary
- resume emulation and hide contextual menu when left-clicking the Game Boy screen

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_6856a7b0dd7483259913a28aac71146f