### PR TITLE
Add basic VRAM viewer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ env_logger = "0.11"
 bytemuck = "1.14"
 rfd = "0.15"
 
+[features]
+default = []
+debug-ui = []
+
 [lib]
 path = "src/lib.rs"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ use rfd::FileDialog;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(feature = "debug-ui")]
+use ui::vram_viewer::VramViewer;
 use winit::dpi::PhysicalPosition;
 use winit::{
     event::MouseButton,
@@ -30,13 +32,26 @@ use winit::{
 
 const SCALE: u32 = 3;
 
-#[derive(Default)]
 struct UiState {
     paused: bool,
     show_context: bool,
     ctx_pos: [f32; 2],
     spawn_debugger: bool,
-    spawn_vram: bool,
+    #[cfg(feature = "debug-ui")]
+    vram_viewer: VramViewer,
+}
+
+impl Default for UiState {
+    fn default() -> Self {
+        Self {
+            paused: false,
+            show_context: false,
+            ctx_pos: [0.0, 0.0],
+            spawn_debugger: false,
+            #[cfg(feature = "debug-ui")]
+            vram_viewer: VramViewer::new(),
+        }
+    }
 }
 
 use ui::window::resize_pixels;
@@ -117,30 +132,6 @@ fn spawn_debugger_window(
     windows.insert(ui_win.win.id(), ui_win);
 }
 
-fn spawn_vram_window(
-    event_loop: &winit::event_loop::EventLoopWindowTarget<()>,
-    platform: &mut WinitPlatform,
-    imgui: &mut ImguiContext,
-    windows: &mut HashMap<winit::window::WindowId, UiWindow>,
-) {
-    use winit::dpi::LogicalSize;
-
-    let w = winit::window::WindowBuilder::new()
-        .with_title("vibeEmu \u{2013} VRAM")
-        .with_inner_size(LogicalSize::new((160 * SCALE) as f64, (144 * SCALE) as f64))
-        .build(event_loop)
-        .unwrap();
-
-    let size = w.inner_size();
-    let surface = pixels::SurfaceTexture::new(size.width, size.height, &w);
-    let pixels = pixels::Pixels::new(1, 1, surface).expect("Pixels error");
-
-    platform.attach_window(imgui.io_mut(), &w, HiDpiMode::Rounded);
-
-    let ui_win = UiWindow::new(WindowKind::VramViewer, w, pixels, imgui);
-    windows.insert(ui_win.win.id(), ui_win);
-}
-
 fn draw_debugger(pixels: &mut Pixels, gb: &mut gameboy::GameBoy, ui: &imgui::Ui) {
     let _ = pixels.frame_mut();
     if let Some(_table) = ui.begin_table("regs", 2) {
@@ -207,11 +198,6 @@ fn draw_debugger(pixels: &mut Pixels, gb: &mut gameboy::GameBoy, ui: &imgui::Ui)
     }
 }
 
-fn draw_vram(pixels: &mut Pixels, _gb: &mut gameboy::GameBoy, ui: &imgui::Ui) {
-    let _ = pixels.frame_mut();
-    ui.text("VRAM viewer not implemented");
-}
-
 fn draw_game_screen(pixels: &mut Pixels, frame: &[u32]) {
     let pixel_frame: &mut [u32] = bytemuck::cast_slice_mut(pixels.frame_mut());
     for (dst, src) in pixel_frame.iter_mut().zip(frame) {
@@ -264,8 +250,9 @@ fn build_ui(
                     state.spawn_debugger = true;
                     close_menu = true;
                 }
+                #[cfg(feature = "debug-ui")]
                 if ui.button("VRAM Viewer") {
-                    state.spawn_vram = true;
+                    state.vram_viewer.open = true;
                     close_menu = true;
                 }
             });
@@ -473,9 +460,17 @@ fn main() {
                             WindowKind::Main => {
                                 build_ui(&mut ui_state, ui, &mut gb, target, &mut platform);
                                 draw_game_screen(&mut win.pixels, &frame);
+                                #[cfg(feature = "debug-ui")]
+                                ui_state.vram_viewer.ui(
+                                    ui,
+                                    &gb.mmu.ppu,
+                                    &gb.mmu,
+                                    win.pixels.device(),
+                                    win.pixels.queue(),
+                                    &mut win.renderer,
+                                );
                             }
                             WindowKind::Debugger => draw_debugger(&mut win.pixels, &mut gb, ui),
-                            WindowKind::VramViewer => draw_vram(&mut win.pixels, &mut gb, ui),
                         }
 
                         platform.prepare_render(ui, &win.win);
@@ -534,15 +529,6 @@ fn main() {
                         spawn_debugger_window(target, &mut platform, &mut imgui, &mut windows);
                         ui_state.paused = true;
                         ui_state.spawn_debugger = false;
-                    }
-                    if ui_state.spawn_vram
-                        && !windows
-                            .values()
-                            .any(|w| matches!(w.kind, WindowKind::VramViewer))
-                    {
-                        spawn_vram_window(target, &mut platform, &mut imgui, &mut windows);
-                        ui_state.paused = true;
-                        ui_state.spawn_vram = false;
                     }
                 }
                 Event::MainEventsCleared => {

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -96,6 +96,18 @@ impl Mmu {
         Self::new_with_mode(false)
     }
 
+    /// Return true if running in CGB mode.
+    pub fn is_cgb(&self) -> bool {
+        self.cgb_mode
+    }
+
+    /// Directly read from VRAM ignoring mode timing.
+    pub fn vram_read(&self, addr: u16) -> u8 {
+        let off = (addr - 0x8000) as usize;
+        let bank = off / 0x2000;
+        self.ppu.vram[bank][off % 0x2000]
+    }
+
     pub fn load_cart(&mut self, cart: Cartridge) {
         let is_dmg = !cart.cgb;
         self.cart = Some(cart);
@@ -219,6 +231,7 @@ impl Mmu {
             0x8000..=0x9FFF => {
                 if self.ppu.mode != 3 {
                     self.ppu.vram[self.ppu.vram_bank][(addr - 0x8000) as usize] = val;
+                    self.ppu.mark_vram_change();
                 }
             }
             0x0000..=0x7FFF | 0xA000..=0xBFFF => {
@@ -290,7 +303,10 @@ impl Mmu {
                     self.rp = val & 0xC1;
                 }
             }
-            0xFF4F => self.ppu.vram_bank = (val & 0x01) as usize,
+            0xFF4F => {
+                self.ppu.vram_bank = (val & 0x01) as usize;
+                self.ppu.mark_vram_change();
+            }
             0xFF46 => {
                 self.ppu.dma = val;
                 let src = (val as u16) << 8;
@@ -312,6 +328,7 @@ impl Mmu {
     /// Write to VRAM bypassing mode checks (used by DMA transfers)
     fn vram_dma_write(&mut self, addr: u16, val: u8) {
         self.ppu.vram[self.ppu.vram_bank][(addr - 0x8000) as usize] = val;
+        self.ppu.mark_vram_change();
     }
 
     pub fn take_serial(&mut self) -> Vec<u8> {

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -77,6 +77,8 @@ pub struct Ppu {
     /// Indicates a completed frame is available in `framebuffer`
     frame_ready: bool,
     prev_stat_irq: u8,
+    /// Monotonically increasing counter for VRAM changes
+    vram_revision: u64,
 }
 
 /// Default DMG palette colors in 0x00RRGGBB order for the `pixels` crate.
@@ -125,6 +127,7 @@ impl Ppu {
             sprite_count: 0,
             frame_ready: false,
             prev_stat_irq: 0,
+            vram_revision: 0,
         }
     }
 
@@ -156,6 +159,92 @@ impl Ppu {
             // DMG-style priority: sort by X position then OAM index
             self.line_sprites[..self.sprite_count].sort_by_key(|s| (s.x, s.oam_index));
         }
+    }
+
+    /// Increment the VRAM revision counter.
+    pub(crate) fn mark_vram_change(&mut self) {
+        self.vram_revision = self.vram_revision.wrapping_add(1);
+    }
+
+    /// Return the current VRAM revision number.
+    pub fn vram_revision(&self) -> u64 {
+        self.vram_revision
+    }
+
+    /// Return the base address of the current BG map.
+    pub fn bg_map_base(&self) -> u16 {
+        if self.lcdc & 0x08 != 0 {
+            0x9C00
+        } else {
+            0x9800
+        }
+    }
+
+    /// Return the base address of the BG tileset.
+    pub fn bg_tiles_base(&self) -> u16 {
+        if self.lcdc & 0x10 != 0 {
+            0x8000
+        } else {
+            0x8800
+        }
+    }
+
+    /// Decode a background tile into an RGBA buffer.
+    pub fn decode_bg_tile_rgba(
+        &self,
+        tile_no: u8,
+        attr: u8,
+        _mmu: &crate::mmu::Mmu,
+    ) -> [u8; 8 * 8 * 4] {
+        let mut out = [0u8; 8 * 8 * 4];
+        let base = if self.lcdc & 0x10 != 0 {
+            TILE_DATA_0_BASE
+        } else {
+            TILE_DATA_1_BASE
+        };
+        let tile_index = if self.lcdc & 0x10 != 0 {
+            tile_no as i16
+        } else {
+            tile_no as i8 as i16 + 128
+        } as usize;
+        let addr = base + tile_index * 16;
+        let mut bank = 0usize;
+        let mut palette = 0usize;
+        let mut flip_x = false;
+        let mut flip_y = false;
+        if self.cgb {
+            palette = (attr & 0x07) as usize;
+            bank = if attr & 0x08 != 0 { 1 } else { 0 };
+            flip_x = attr & 0x20 != 0;
+            flip_y = attr & 0x40 != 0;
+        }
+
+        for y in 0..8 {
+            let py = if flip_y { 7 - y } else { y };
+            let lo = self.vram[bank][addr + py * 2];
+            let hi = self.vram[bank][addr + py * 2 + 1];
+            for x in 0..8 {
+                let bit = if flip_x { x } else { 7 - x };
+                let color_id = ((hi >> bit) & 1) << 1 | ((lo >> bit) & 1);
+                let color = if self.cgb {
+                    let off = palette * 8 + color_id as usize * 2;
+                    Self::decode_cgb_color(self.bgpd[off], self.bgpd[off + 1])
+                } else {
+                    let idx = Self::dmg_shade(self.bgp, color_id);
+                    DMG_PALETTE[idx as usize]
+                };
+                let r = ((color >> 16) & 0xFF) as u8;
+                let g = ((color >> 8) & 0xFF) as u8;
+                let b = (color & 0xFF) as u8;
+                let off = (y * 8 + x) * 4;
+                out[off] = r;
+                out[off + 1] = g;
+                out[off + 2] = b;
+                out[off + 3] = 0xFF;
+            }
+        }
+
+        out
     }
 
     pub fn new() -> Self {
@@ -275,9 +364,18 @@ impl Ppu {
             0xFF44 => {}
             0xFF45 => self.lyc = val,
             0xFF46 => self.dma = val,
-            0xFF47 => self.bgp = val,
-            0xFF48 => self.obp0 = val,
-            0xFF49 => self.obp1 = val,
+            0xFF47 => {
+                self.bgp = val;
+                self.mark_vram_change();
+            }
+            0xFF48 => {
+                self.obp0 = val;
+                self.mark_vram_change();
+            }
+            0xFF49 => {
+                self.obp1 = val;
+                self.mark_vram_change();
+            }
             0xFF4A => self.wy = val,
             0xFF4B => self.wx = val,
             0xFF68 => self.bgpi = val,
@@ -287,6 +385,7 @@ impl Ppu {
                 if self.bgpi & 0x80 != 0 {
                     self.bgpi = (self.bgpi & 0x80) | ((idx as u8 + 1) & 0x3F);
                 }
+                self.mark_vram_change();
             }
             0xFF6A => self.obpi = val,
             0xFF6B => {
@@ -295,6 +394,7 @@ impl Ppu {
                 if self.obpi & 0x80 != 0 {
                     self.obpi = (self.obpi & 0x80) | ((idx as u8 + 1) & 0x3F);
                 }
+                self.mark_vram_change();
             }
             0xFF6C => self.opri = val & 0x01,
             _ => {}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,1 +1,3 @@
+#[cfg(feature = "debug-ui")]
+pub mod vram_viewer;
 pub mod window;

--- a/src/ui/vram_viewer.rs
+++ b/src/ui/vram_viewer.rs
@@ -1,0 +1,233 @@
+use imgui::*;
+use imgui_wgpu::Renderer;
+use wgpu::{Device, Queue, TextureFormat};
+
+use crate::mmu::Mmu;
+use crate::ppu::Ppu;
+
+/// Size of a single Game Boy tile in pixels (always 8×8).
+const TILE_PX: usize = 8;
+/// Background map is 32×32 tiles.
+const BG_SIZE_TILES: usize = 32;
+/// Final BG texture is 256×256 px
+const BG_PX: usize = BG_SIZE_TILES * TILE_PX;
+
+/// A texture we hand to ImGui that mirrors the current BG map.
+struct BgTexture {
+    id: TextureId,
+    /// Increment this when VRAM changes so [`Renderer::update_texture`] runs O(n)
+    version: u64,
+}
+
+/// High-level state for the VRAM viewer window.
+pub struct VramViewer {
+    pub open: bool,
+    /// Which tab is currently visible.
+    tab: usize,
+    /// User toggles.
+    show_grid: bool,
+    scx_scxy_overlay: bool,
+    show_palette: bool,
+    /// Cached BG map texture (only recreated when VRAM changes).
+    bg: Option<BgTexture>,
+}
+
+impl VramViewer {
+    pub fn new() -> Self {
+        Self {
+            open: false,
+            tab: 0,
+            show_grid: true,
+            scx_scxy_overlay: true,
+            show_palette: true,
+            bg: None,
+        }
+    }
+
+    // Call every frame from the main UI loop.
+    pub fn ui(
+        &mut self,
+        ui: &Ui,
+        ppu: &Ppu,
+        mmu: &Mmu,
+        device: &Device,
+        queue: &Queue,
+        renderer: &mut Renderer,
+    ) {
+        if !self.open {
+            return;
+        }
+        ui.window("VRAM Viewer")
+            .size([560.0, 430.0], Condition::FirstUseEver)
+            .build(|| {
+                Self::top_tabs(ui, |tab| self.tab = tab);
+                match self.tab {
+                    0 => self.bg_map_tab(ui, ppu, mmu, device, queue, renderer),
+                    1 => self.tiles_tab(ui),
+                    2 => self.oam_tab(ui),
+                    3 => self.palettes_tab(ui),
+                    _ => {}
+                }
+            });
+    }
+
+    /// Render tab bar.
+    fn top_tabs(ui: &Ui, mut pick: impl FnMut(usize)) {
+        TabBar::new("vram_tabs").build(ui, || {
+            if TabItem::new("BG map").build(ui, || {}).is_some() {
+                pick(0);
+            }
+            if TabItem::new("Tiles").build(ui, || {}).is_some() {
+                pick(1);
+            }
+            if TabItem::new("OAM").build(ui, || {}).is_some() {
+                pick(2);
+            }
+            if TabItem::new("Palettes").build(ui, || {}).is_some() {
+                pick(3);
+            }
+        });
+    }
+
+    // ────────────────────────────── BG MAP TAB ─────────────────────────────
+    fn bg_map_tab(
+        &mut self,
+        ui: &Ui,
+        ppu: &Ppu,
+        mmu: &Mmu,
+        device: &Device,
+        queue: &Queue,
+        renderer: &mut Renderer,
+    ) {
+        // Ensure texture is up-to-date
+        let vram_revision = ppu.vram_revision(); // <- expose this getter
+        let needs_upload = self
+            .bg
+            .as_ref()
+            .map(|b| b.version != vram_revision)
+            .unwrap_or(true);
+
+        if needs_upload {
+            let tex = self.upload_bg_texture(ppu, mmu, device, queue, renderer);
+            self.bg = Some(BgTexture {
+                id: tex,
+                version: vram_revision,
+            });
+        }
+
+        // Split window: left = map, right = info sidebar
+        ui.columns(2, "bg_columns", true);
+        {
+            // --- Left: big texture preview ---
+            let avail = ui.content_region_avail();
+            let size = avail[0].min(avail[1]);
+            if let Some(bg) = &self.bg {
+                Image::new(bg.id, [size, size]).build(ui);
+                if self.show_grid {
+                    // Overlay grid lines
+                    let draw = ui.get_window_draw_list();
+                    let top_left = ui.cursor_screen_pos();
+                    let step = size / BG_SIZE_TILES as f32;
+                    for i in 0..=BG_SIZE_TILES {
+                        let x = top_left[0] + i as f32 * step;
+                        let y = top_left[1] + i as f32 * step;
+                        let _ = draw
+                            .add_line(
+                                [top_left[0], y],
+                                [top_left[0] + size, y],
+                                [1.0, 1.0, 1.0, 0.25],
+                            )
+                            .thickness(1.0);
+                        let _ = draw
+                            .add_line(
+                                [x, top_left[1]],
+                                [x, top_left[1] + size],
+                                [1.0, 1.0, 1.0, 0.25],
+                            )
+                            .thickness(1.0);
+                    }
+                }
+                // TODO: mouse-over tile details (see sidebar sketch below)
+            }
+        }
+        ui.next_column();
+        {
+            // --- Right: Details panel ---
+            ui.text("Details");
+            ui.separator();
+            ui.checkbox("Grid", &mut self.show_grid);
+            ui.checkbox("scx/y", &mut self.scx_scxy_overlay);
+            ui.checkbox("pal", &mut self.show_palette);
+            ui.separator();
+            ui.text(format!("Map base: ${:04X}", ppu.bg_map_base()));
+            ui.text(format!("Tileset base: ${:04X}", ppu.bg_tiles_base()));
+            // (Add more fields here as needed)
+        }
+        ui.columns(1, "", false);
+    }
+
+    /// Generate a 256×256 RGBA texture representing the full BG map.
+    ///
+    /// NOTE: *Slow but easy to reason about.* Feel free to SIMD/parallelise later.
+    fn upload_bg_texture(
+        &self,
+        ppu: &Ppu,
+        mmu: &Mmu,
+        device: &Device,
+        queue: &Queue,
+        renderer: &mut Renderer,
+    ) -> TextureId {
+        let mut rgba = vec![0u8; BG_PX * BG_PX * 4];
+        let map_base = ppu.bg_map_base();
+
+        for ty in 0..BG_SIZE_TILES {
+            for tx in 0..BG_SIZE_TILES {
+                let map_index = (ty * BG_SIZE_TILES + tx) as u16;
+                let tile_no = mmu.vram_read(map_base + map_index);
+                let attr = if mmu.is_cgb() {
+                    mmu.vram_read(map_base + 0x2000 + map_index)
+                } else {
+                    0
+                };
+
+                // Decode tile into 8×8 px RGBA
+                let tile_rgba = ppu.decode_bg_tile_rgba(tile_no, attr, mmu);
+                let dst_y = ty * TILE_PX;
+                let dst_x = tx * TILE_PX;
+                for py in 0..TILE_PX {
+                    let dst_offset = ((dst_y + py) * BG_PX + dst_x) * 4;
+                    rgba[dst_offset..dst_offset + TILE_PX * 4]
+                        .copy_from_slice(&tile_rgba[py * TILE_PX * 4..(py + 1) * TILE_PX * 4]);
+                }
+            }
+        }
+
+        // Upload / update ImGui texture
+        let tex = imgui_wgpu::Texture::new(
+            device,
+            renderer,
+            imgui_wgpu::TextureConfig {
+                size: wgpu::Extent3d {
+                    width: BG_PX as u32,
+                    height: BG_PX as u32,
+                    depth_or_array_layers: 1,
+                },
+                format: Some(TextureFormat::Rgba8UnormSrgb),
+                ..Default::default()
+            },
+        );
+        tex.write(queue, &rgba, BG_PX as u32, BG_PX as u32);
+        renderer.textures.insert(tex)
+    }
+
+    // ────────────────────────────── STUB TABS ──────────────────────────────
+    fn tiles_tab(&self, ui: &Ui) {
+        ui.text("Tiles tab – TBD");
+    }
+    fn oam_tab(&self, ui: &Ui) {
+        ui.text("OAM tab – TBD");
+    }
+    fn palettes_tab(&self, ui: &Ui) {
+        ui.text("Palettes tab – TBD");
+    }
+}

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -17,7 +17,6 @@ pub struct UiWindow {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum WindowKind {
     Debugger,
-    VramViewer,
     Main,
 }
 


### PR DESCRIPTION
## Summary
- add debug-ui feature gate
- expose PPU VRAM helpers and versioning
- add direct VRAM access helpers in MMU
- implement interactive VRAM viewer
- integrate viewer into main UI

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_6856b9a0a8cc8325a0e592332e571dd8