### PR TITLE
Set window scale to 2x

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use winit::{
     window::WindowBuilder,
 };
 
-const SCALE: u32 = 3;
+const SCALE: u32 = 2;
 
 #[derive(Default)]
 struct UiState {


### PR DESCRIPTION
## Summary
- default UI window scale to 2x so the emulator opens at a 320x288 resolution

## Testing
- `cargo clippy`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_6856fc5a535c83258660d132ff7c9c6a