### PR TITLE
Add PCM12/PCM34 APU registers

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -476,6 +476,17 @@ impl Apu {
         self.regs[idx] | Apu::read_mask(addr)
     }
 
+    pub fn read_pcm(&self, addr: u16) -> u8 {
+        if self.nr52 & 0x80 == 0 {
+            return 0xFF;
+        }
+        match addr {
+            0xFF76 => (self.ch2.output() << 4) | self.ch1.output(),
+            0xFF77 => (self.ch4.output() << 4) | self.ch3.output(),
+            _ => 0xFF,
+        }
+    }
+
     pub fn write_reg(&mut self, addr: u16, val: u8) {
         if self.nr52 & 0x80 == 0 && addr != 0xFF26 && !(0xFF30..=0xFF3F).contains(&addr) {
             return;

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -332,6 +332,8 @@ pub struct Apu {
     hp_prev_output_left: f32,
     hp_prev_input_right: f32,
     hp_prev_output_right: f32,
+    pcm12: u8,
+    pcm34: u8,
     regs: [u8; 0x30],
     wave_shadow: [u8; 0x10],
 }
@@ -398,6 +400,8 @@ impl Apu {
         self.hp_prev_output_left = 0.0;
         self.hp_prev_input_right = 0.0;
         self.hp_prev_output_right = 0.0;
+        self.pcm12 = 0;
+        self.pcm34 = 0;
     }
     pub fn new() -> Self {
         let mut apu = Self {
@@ -421,6 +425,8 @@ impl Apu {
             hp_prev_output_left: 0.0,
             hp_prev_input_right: 0.0,
             hp_prev_output_right: 0.0,
+            pcm12: 0,
+            pcm34: 0,
         };
 
         // Initialize channels to power-on register defaults
@@ -481,8 +487,8 @@ impl Apu {
             return 0xFF;
         }
         match addr {
-            0xFF76 => (self.ch2.output() << 4) | self.ch1.output(),
-            0xFF77 => (self.ch4.output() << 4) | self.ch3.output(),
+            0xFF76 => self.pcm12,
+            0xFF77 => self.pcm34,
             _ => 0xFF,
         }
     }
@@ -688,10 +694,18 @@ impl Apu {
     }
 
     fn mix_output(&mut self) -> (i16, i16) {
-        let ch1 = self.ch1.output() as i16 - 8;
-        let ch2 = self.ch2.output() as i16 - 8;
-        let ch3 = self.ch3.output() as i16 - 8;
-        let ch4 = self.ch4.output() as i16 - 8;
+        let out1 = self.ch1.output();
+        let out2 = self.ch2.output();
+        let out3 = self.ch3.output();
+        let out4 = self.ch4.output();
+
+        self.pcm12 = (out2 << 4) | out1;
+        self.pcm34 = (out4 << 4) | out3;
+
+        let ch1 = out1 as i16 - 8;
+        let ch2 = out2 as i16 - 8;
+        let ch3 = out3 as i16 - 8;
+        let ch4 = out4 as i16 - 8;
 
         let mut left = 0i16;
         let mut right = 0i16;

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -189,6 +189,13 @@ impl Mmu {
             }
             0xFF4F => self.ppu.vram_bank as u8,
             0xFF70 => self.wram_bank as u8,
+            0xFF76 | 0xFF77 => {
+                if self.cgb_mode {
+                    self.apu.lock().unwrap().read_pcm(addr)
+                } else {
+                    0xFF
+                }
+            }
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
             0xFFFF => self.ie_reg,
             _ => 0xFF,


### PR DESCRIPTION
## Summary
- expose CGB PCM output registers FF76/FF77 via `MMU::read_byte`
- implement `Apu::read_pcm` for instantaneous channel samples

## Testing
- `cargo fmt --all`
- `cargo clippy`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_6857321fe4d883259f65c1cbe6e78d38