### PR TITLE
Add branding assets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ log = "0.4"
 env_logger = "0.11"
 bytemuck = "1.14"
 rfd = "0.15"
+image = { version = "0.24", default-features = false, features = ["png"] }
 
 [lib]
 path = "src/lib.rs"
 
 [dev-dependencies]
 tempfile = "3"
-image = { version = "0.24", default-features = false, features = ["png"] }
 once_cell = "1"
 reqwest = { version = "0.11", features = ["blocking", "gzip"] }
 zip = "0.6"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # vibeEmu
 
+![vibeEmu Logo](gfx/vibeEmu_512px.png)
+
 vibeEmu is a Game Boy and Game Boy Color emulator written in Rust.  It now
 features a cycle‑accurate CPU, MMU, PPU and APU along with a `winit` + `pixels`
 frontend.  An ImGui powered debug UI exposes a register viewer and a VRAM

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,19 @@ use winit::{
     event::MouseButton,
     event::{ElementState, Event, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::WindowBuilder,
+    window::{Icon, WindowBuilder},
 };
+
+fn load_window_icon() -> Option<Icon> {
+    let icon_data = include_bytes!("../gfx/vibeEmu_512px.png");
+    if let Ok(img) = image::load_from_memory(icon_data) {
+        let img = img.into_rgba8();
+        let (w, h) = (img.width(), img.height());
+        Icon::from_rgba(img.into_raw(), w, h).ok()
+    } else {
+        None
+    }
+}
 
 const SCALE: u32 = 2;
 const GB_FPS: f64 = 59.7275;
@@ -114,6 +125,7 @@ fn spawn_debugger_window(
 
     let w = winit::window::WindowBuilder::new()
         .with_title("vibeEmu \u{2013} Debugger")
+        .with_window_icon(load_window_icon())
         .with_inner_size(LogicalSize::new((160 * SCALE) as f64, (144 * SCALE) as f64))
         .build(event_loop)
         .unwrap();
@@ -138,6 +150,7 @@ fn spawn_vram_window(
 
     let w = winit::window::WindowBuilder::new()
         .with_title("vibeEmu \u{2013} VRAM")
+        .with_window_icon(load_window_icon())
         .with_inner_size(LogicalSize::new((160 * SCALE) as f64, (144 * SCALE) as f64))
         .build(event_loop)
         .unwrap();
@@ -380,6 +393,7 @@ fn main() {
         let event_loop = EventLoop::new();
         let window = WindowBuilder::new()
             .with_title("vibeEmu")
+            .with_window_icon(load_window_icon())
             .with_inner_size(winit::dpi::LogicalSize::new(
                 (160 * SCALE) as f64,
                 (144 * SCALE) as f64,


### PR DESCRIPTION
## Summary
- display 512x512 logo in README
- load bundled icon and use it for all emulator windows
- make `image` a runtime dependency

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --verbose` *(fails: rom not found)*
- `cargo test --release -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68573b40948c832591b25dfe97e65bef