### PR TITLE
apu: preserve square timer phase

### DIFF
--- a/tests/apu.rs
+++ b/tests/apu.rs
@@ -130,7 +130,7 @@ fn pcm_register_sample_values() {
     apu.write_reg(0xFF17, 0xF0);
     apu.write_reg(0xFF19, 0x80); // trigger
 
-    apu.step(100);
+    apu.step(200);
 
     assert_eq!(apu.read_pcm(0xFF76), 0xF0);
 }
@@ -144,7 +144,7 @@ fn pcm_mmu_mapping() {
     mmu.write_byte(0xFF16, 0xC0);
     mmu.write_byte(0xFF17, 0xF0);
     mmu.write_byte(0xFF19, 0x80);
-    mmu.apu.lock().unwrap().step(100);
+    mmu.apu.lock().unwrap().step(200);
     assert_eq!(mmu.read_byte(0xFF76), 0xF0);
     let mut dmg = Mmu::new();
     assert_eq!(dmg.read_byte(0xFF76), 0xFF);


### PR DESCRIPTION
## Summary
- keep duty timer low bits when triggering square channels
- force first sample to zero to mimic hardware
- update tests to allow initial zero sample

## Testing
- `cargo clippy`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_685744f8e8b48325b6d15f8219178258