### PR TITLE
Embed Windows icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,6 +3442,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3633,7 @@ dependencies = [
  "tempfile",
  "wgpu",
  "winit",
+ "winres",
  "zip",
 ]
 
@@ -4387,6 +4397,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winres"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+dependencies = [
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vibeEmu"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -20,6 +21,9 @@ image = { version = "0.24", default-features = false, features = ["png"] }
 
 [lib]
 path = "src/lib.rs"
+
+[build-dependencies]
+winres = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+fn main() {
+    #[cfg(target_os = "windows")]
+    {
+        use std::path::Path;
+        let mut res = winres::WindowsResource::new();
+        res.set_icon("gfx/vibeEmu.ico");
+        if let Err(e) = res.compile() {
+            println!("cargo:warning=winres failed: {}", e);
+        }
+        println!(
+            "cargo:rerun-if-changed={}",
+            Path::new("gfx/vibeEmu.ico").display()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add build script using winres to embed `gfx/vibeEmu.ico`
- enable build.rs in Cargo configuration

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1 --nocapture` *(fails: rom not found)*


------
https://chatgpt.com/codex/tasks/task_e_685859ade5b4832586b7bbec91b3e99b