### PR TITLE
Fix CPU-aligned channel 1 test

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -467,7 +467,6 @@ impl Apu {
         self.hp_prev_output_right = 0.0;
         self.pcm12 = 0;
         self.pcm34 = 0;
-        self.cpu_cycles = 0;
     }
     pub fn new() -> Self {
         let mut apu = Self {
@@ -679,6 +678,8 @@ impl Apu {
                         self.ch1.out_stage1 = 0;
                         self.ch2.out_latched = 0;
                         self.ch2.out_stage1 = 0;
+                        self.cpu_cycles = 0;
+                        self.sequencer.step = 0;
                     }
                     self.nr52 |= 0x80;
                 }

--- a/tests/same_suite.rs
+++ b/tests/same_suite.rs
@@ -27,7 +27,6 @@ fn same_suite__apu__channel_1__channel_1_align_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__apu__channel_1__channel_1_align_cpu_gb() {
     let passed = run_same_suite(
         common::rom_path("same-suite/apu/channel_1/channel_1_align_cpu.gb"),


### PR DESCRIPTION
## Summary
- reset audio timing counters when enabling NR52
- ensure DIV-APU continues running while sound is off
- enable `channel_1_align_cpu` SameSuite test

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --test same_suite -- --ignored --exact same_suite__apu__channel_1__channel_1_align_cpu_gb`

------
https://chatgpt.com/codex/tasks/task_e_685862c298388325bef425a3bc80526f