### PR TITLE
Unignore passing dmg_sound test

### DIFF
--- a/tests/dmg_sound_roms.rs
+++ b/tests/dmg_sound_roms.rs
@@ -84,7 +84,6 @@ fn dmg_sound_06_overflow_on_trigger() {
 }
 
 #[test]
-#[ignore]
 fn dmg_sound_07_len_sweep_period_sync() {
     run_single("07-len sweep period sync.gb");
 }


### PR DESCRIPTION
## Summary
- reintroduce `#[ignore]` on failing tests
- keep `dmg_sound_07_len_sweep_period_sync` active as it now passes

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --no-fail-fast`
- `cargo test --release --no-fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_68586a33f6bc83259e29af8f4c3cc357