### PR TITLE
Adjust samesuite test ignores

### DIFF
--- a/tests/same_suite.rs
+++ b/tests/same_suite.rs
@@ -235,7 +235,6 @@ fn same_suite__apu__channel_2__channel_2_align_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__apu__channel_2__channel_2_align_cpu_gb() {
     let passed = run_same_suite(
         common::rom_path("same-suite/apu/channel_2/channel_2_align_cpu.gb"),


### PR DESCRIPTION
## Summary
- run all `same_suite` tests and re-enable only the ones that pass

## Testing
- `cargo test --test same_suite -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `cargo test --release -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_68586db98a288325b683feae975ca36f