### PR TITLE
Refactor audio output

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,87 @@
+use crate::apu::Apu;
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use std::sync::{Arc, Mutex};
+
+/// Start audio playback using `cpal` and stream samples produced by the APU.
+///
+/// Returns the active [`cpal::Stream`] if successful.
+pub fn start_stream(apu: Arc<Mutex<Apu>>) -> Option<cpal::Stream> {
+    let host = cpal::default_host();
+    let device = host.default_output_device()?;
+    let supported = match device.default_output_config() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("no supported output config: {e}");
+            return None;
+        }
+    };
+    let sample_format = supported.sample_format();
+    let config: cpal::StreamConfig = supported.into();
+    {
+        let mut a = apu.lock().unwrap();
+        a.set_sample_rate(config.sample_rate.0);
+    }
+    let channels = config.channels as usize;
+    let err_fn = |err| eprintln!("cpal stream error: {err}");
+
+    let stream = match sample_format {
+        cpal::SampleFormat::I16 => device
+            .build_output_stream(
+                &config,
+                move |data: &mut [i16], _| {
+                    let mut apu = apu.lock().unwrap();
+                    for frame in data.chunks_mut(channels) {
+                        let left = apu.pop_sample().unwrap_or(0);
+                        let right = apu.pop_sample().unwrap_or(0);
+                        frame[0] = left;
+                        if channels > 1 {
+                            frame[1] = right;
+                        }
+                    }
+                },
+                err_fn,
+                None,
+            )
+            .unwrap(),
+        cpal::SampleFormat::U16 => device
+            .build_output_stream(
+                &config,
+                move |data: &mut [u16], _| {
+                    let mut apu = apu.lock().unwrap();
+                    for frame in data.chunks_mut(channels) {
+                        let left = apu.pop_sample().unwrap_or(0);
+                        let right = apu.pop_sample().unwrap_or(0);
+                        frame[0] = (left as i32 + 32768) as u16;
+                        if channels > 1 {
+                            frame[1] = (right as i32 + 32768) as u16;
+                        }
+                    }
+                },
+                err_fn,
+                None,
+            )
+            .unwrap(),
+        cpal::SampleFormat::F32 => device
+            .build_output_stream(
+                &config,
+                move |data: &mut [f32], _| {
+                    let mut apu = apu.lock().unwrap();
+                    for frame in data.chunks_mut(channels) {
+                        let left = apu.pop_sample().unwrap_or(0) as f32 / 32768.0;
+                        let right = apu.pop_sample().unwrap_or(0) as f32 / 32768.0;
+                        frame[0] = left;
+                        if channels > 1 {
+                            frame[1] = right;
+                        }
+                    }
+                },
+                err_fn,
+                None,
+            )
+            .unwrap(),
+        _ => panic!("Unsupported sample format"),
+    };
+
+    stream.play().expect("failed to play stream");
+    Some(stream)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 
 pub mod apu;
+pub mod audio;
 pub mod cartridge;
 pub mod cpu;
 pub mod gameboy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 mod apu;
+mod audio;
 mod cartridge;
 mod cpu;
 mod gameboy;
@@ -378,7 +379,7 @@ fn main() {
     let _stream = if args.headless {
         None
     } else {
-        apu::Apu::start_stream(Arc::clone(&gb.mmu.apu))
+        audio::start_stream(Arc::clone(&gb.mmu.apu))
     };
 
     let mut frame = vec![0u32; 160 * 144];


### PR DESCRIPTION
## Summary
- separate cpal audio output code from APU implementation
- expose new `audio` module with `start_stream`
- update main crate to use the new module
- add helper `set_sample_rate` in APU

## Testing
- `cargo fmt --all`
- `cargo clippy`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_6859d22d1d188325bab4bf5ff5b03054