### PR TITLE
Fix APU trigger timing

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -5,9 +5,9 @@ const CPU_CLOCK_HZ: u32 = 4_194_304;
 const FRAME_SEQUENCER_PERIOD: u32 = 8192;
 const VOLUME_FACTOR: i16 = 64;
 pub const AUDIO_LATENCY_MS: u32 = 40;
-/// Hardware waits exactly **one machine-cycle (4 CPU cycles)** between a
-/// channel trigger and the first tick of its frequency timer.
-const TRIGGER_DELAY_CYCLES: i32 = 4; // cycles
+// On real hardware the first frequency-timer decrement occurs one CPU tick
+// after a trigger. We model this delay with a flag instead of adjusting the
+// timer value.
 
 const POWER_ON_REGS: [u8; 0x30] = [
     0x80, 0xBF, 0xF3, 0xFF, 0xBF, 0xFF, 0x3F, 0x00, 0xFF, 0xBF, 0x7F, 0xFF, 0x9F, 0xFF, 0xBF, 0xFF,
@@ -91,6 +91,8 @@ struct SquareChannel {
     duty: u8,
     duty_pos: u8,
     pending_reset: bool,
+    /// Skip one decrement cycle immediately after a trigger.
+    skip_decrement: bool,
     frequency: u16,
     timer: i32,
     envelope: Envelope,
@@ -120,15 +122,22 @@ impl SquareChannel {
             return;
         }
         let mut cycles = cycles as i32;
+
+        if self.skip_decrement {
+            self.skip_decrement = false;
+            if cycles == 0 {
+                return;
+            }
+            cycles -= 1;
+            self.pending_reset = false;
+            self.duty_pos = 0;
+            self.timer -= 1;
+        }
+
         while self.timer <= cycles {
             cycles -= self.timer;
             self.timer = self.period();
-            if self.pending_reset {
-                self.pending_reset = false;
-                self.duty_pos = 0;
-            } else {
-                self.duty_pos = (self.duty_pos + 1) & 7;
-            }
+            self.duty_pos = (self.duty_pos + 1) & 7;
         }
         self.timer -= cycles;
     }
@@ -701,10 +710,11 @@ impl Apu {
             &mut self.ch2
         };
         ch.enabled = true;
-        // ➊  Reload the 11-bit frequency immediately
-        // ➋  Wait one M-cycle (4 CPU cycles) before the first decrement
+        // Reload the timer and mark that the next decrement should be skipped
+        // for one CPU tick, matching DMG/CGB behaviour.
         let period = ch.period();
-        ch.timer = period + TRIGGER_DELAY_CYCLES;
+        ch.timer = period;
+        ch.skip_decrement = true;
         ch.pending_reset = true;
         ch.envelope.volume = ch.envelope.initial;
         if idx == 1 {

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -95,7 +95,6 @@ struct SquareChannel {
     timer: i32,
     envelope: Envelope,
     sweep: Option<Sweep>,
-    first_sample: bool,
     out_latched: u8,
     out_stage1: u8,
 }
@@ -138,8 +137,7 @@ impl SquareChannel {
         if !self.enabled || !self.dac_enabled {
             return 0;
         }
-        if self.first_sample {
-            self.first_sample = false;
+        if self.pending_reset {
             return 0;
         }
         const DUTY_TABLE: [[u8; 8]; 4] = [
@@ -167,7 +165,7 @@ impl SquareChannel {
     }
 
     fn peek_sample(&self) -> u8 {
-        if !self.enabled || !self.dac_enabled || self.pending_reset || self.first_sample {
+        if !self.enabled || !self.dac_enabled || self.pending_reset {
             return 0;
         }
         const DUTY_TABLE: [[u8; 8]; 4] = [
@@ -708,7 +706,6 @@ impl Apu {
         let period = ch.period();
         ch.timer = period + TRIGGER_DELAY_CYCLES;
         ch.pending_reset = true;
-        ch.first_sample = true;
         ch.envelope.volume = ch.envelope.initial;
         if idx == 1 {
             if let Some(s) = ch.sweep.as_mut() {

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -5,8 +5,9 @@ const CPU_CLOCK_HZ: u32 = 4_194_304;
 const FRAME_SEQUENCER_PERIOD: u32 = 8192;
 const VOLUME_FACTOR: i16 = 64;
 pub const AUDIO_LATENCY_MS: u32 = 40;
-const TRIGGER_PIPELINE_LATENCY: i32 = 2; // cycles
-const ALIGN_TO_NEXT_DIV_EDGE: i32 = 16; // cycles when div_phase == 0
+/// Hardware waits exactly **one machine-cycle (4 CPU cycles)** between a
+/// channel trigger and the first tick of its frequency timer.
+const TRIGGER_DELAY_CYCLES: i32 = 4; // cycles
 
 const POWER_ON_REGS: [u8; 0x30] = [
     0x80, 0xBF, 0xF3, 0xFF, 0xBF, 0xFF, 0x3F, 0x00, 0xFF, 0xBF, 0x7F, 0xFF, 0x9F, 0xFF, 0xBF, 0xFF,
@@ -702,10 +703,10 @@ impl Apu {
             &mut self.ch2
         };
         ch.enabled = true;
-        let div_phase = (self.cpu_cycles & 0x3) as i32;
+        // ➊  Reload the 11-bit frequency immediately
+        // ➋  Wait one M-cycle (4 CPU cycles) before the first decrement
         let period = ch.period();
-        let delay = TRIGGER_PIPELINE_LATENCY + ALIGN_TO_NEXT_DIV_EDGE - div_phase;
-        ch.timer = ((period + delay) & !0x3) | div_phase;
+        ch.timer = period + TRIGGER_DELAY_CYCLES;
         ch.pending_reset = true;
         ch.first_sample = true;
         ch.envelope.volume = ch.envelope.initial;
@@ -787,10 +788,11 @@ impl Apu {
     pub fn tick(&mut self, div_prev: u16, div_now: u16, double_speed: bool) {
         self.ch1.tick_1mhz();
         self.ch2.tick_1mhz();
-        // DIV bit 5 clocks the sequencer at 512 Hz (bit 6 when double-speed)
-        let bit = if double_speed { 6 } else { 5 };
-        let toggled = ((div_prev >> bit) & 1) != ((div_now >> bit) & 1);
-        if toggled {
+        // A 512 Hz tick occurs **on the falling edge** of DIV bit 4
+        // (bit 5 in double-speed mode).
+        let bit = if double_speed { 5 } else { 4 };
+        let falling_edge = ((div_prev >> bit) & 1) == 1 && ((div_now >> bit) & 1) == 0;
+        if falling_edge {
             let step = self.sequencer.advance();
             self.clock_frame_sequencer(step);
         }

--- a/tests/same_suite.rs
+++ b/tests/same_suite.rs
@@ -14,7 +14,12 @@ fn run_same_suite<P: AsRef<std::path::Path>>(rom_path: P, max_cycles: u64) -> bo
         }
     }
     let out = gb.mmu.serial.take_output();
-    out.len() >= 6 && out[0..6] == FIB_SEQ
+    let passed = out.len() >= 6 && out[0..6] == FIB_SEQ;
+    if !passed {
+        let dump = &gb.mmu.wram[0][0..48];
+        println!("WRAM dump: {:02X?}", dump);
+    }
+    passed
 }
 
 #[test]
@@ -36,7 +41,6 @@ fn same_suite__apu__channel_1__channel_1_align_cpu_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__apu__channel_1__channel_1_delay_gb() {
     let passed = run_same_suite(
         common::rom_path("same-suite/apu/channel_1/channel_1_delay.gb"),


### PR DESCRIPTION
## Summary
- apply upstream fixes for APU trigger delay
- detect frame-sequencer edges on DIV bit 4 falling edge
- simplify square channel trigger timing

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` *(fails: same_suite channel align tests)*

------
https://chatgpt.com/codex/tasks/task_e_685b3b5a15ec8325b8e08c56fa97c21c