### PR TITLE
Add NR52 tests and fix timer expression

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -729,7 +729,7 @@ impl Apu {
         }
         let new_timer = sample_length * 2 + delay_cycles;
         let low_phase = (self.lf_div_counter & 0x3) as i32;
-        ch.timer = (new_timer & !0x3) | low_phase + 1;
+        ch.timer = ((new_timer & !0x3) | low_phase) + 1;
         ch.pending_reset = true;
         ch.first_sample = true;
         ch.enabled = true;


### PR DESCRIPTION
## Summary
- add tests for NR52 behavior covering power control, register clearing, channel status bits and wave RAM persistence
- fix ambiguous expression in channel trigger logic

## Testing
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1` *(fails: same_suite__apu__channel_1__channel_1_align_cpu_gb, same_suite__apu__channel_1__channel_1_delay_gb)*
- `cargo test --release -- --test-threads=1` *(fails: same_suite__apu__channel_1__channel_1_align_cpu_gb, same_suite__apu__channel_1__channel_1_delay_gb)*

------
https://chatgpt.com/codex/tasks/task_e_6884f519fb408325884a552415ea63a8