### PR TITLE
Add NR11 tests

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -966,6 +966,16 @@ impl Apu {
         self.ch1.frequency
     }
 
+    /// Current duty setting for channel 1.
+    pub fn ch1_duty(&self) -> u8 {
+        self.ch1.duty
+    }
+
+    /// Current length counter value for channel 1.
+    pub fn ch1_length(&self) -> u8 {
+        self.ch1.length
+    }
+
     pub fn set_sample_rate(&mut self, rate: u32) {
         self.sample_rate = rate;
     }


### PR DESCRIPTION
## Summary
- add getters for channel 1 duty and length
- add NR11 unit tests for duty and length timer behaviour

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`
- `cargo test --quiet --release`


------
https://chatgpt.com/codex/tasks/task_e_68850cbfba9c8325a82e604a6740d26c