### PR TITLE
Add NR13 register tests

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -1001,6 +1001,10 @@ impl Apu {
     pub fn sequencer_step(&self) -> u8 {
         self.sequencer.step
     }
+
+    pub fn ch1_timer(&self) -> i32 {
+        self.ch1.timer
+    }
 }
 
 impl Default for Apu {


### PR DESCRIPTION
## Summary
- add accessor for ch1 timer for testing
- test NR13 write-only behavior and delayed period update

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688513a5a1f083258bd27224ae48453d