### PR TITLE
Add NR30 DAC disable test and fix channel behavior

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -660,7 +660,12 @@ impl Apu {
                     self.trigger_square(2);
                 }
             }
-            0xFF1A => self.ch3.dac_enabled = val & 0x80 != 0,
+            0xFF1A => {
+                self.ch3.dac_enabled = val & 0x80 != 0;
+                if !self.ch3.dac_enabled {
+                    self.ch3.enabled = false;
+                }
+            }
             0xFF1B => self.ch3.length = 256 - val as u16,
             0xFF1C => self.ch3.volume = (val >> 5) & 0x03,
             0xFF1D => self.ch3.frequency = (self.ch3.frequency & 0x700) | val as u16,

--- a/tests/apu.rs
+++ b/tests/apu.rs
@@ -766,3 +766,14 @@ fn wave_channel_wraps_after_32_samples() {
     let sample = apu.read_pcm(0xFF77) & 0x0F;
     assert_eq!(sample, 0);
 }
+
+#[test]
+fn nr30_dac_off_disables_channel() {
+    let mut apu = Apu::new();
+    apu.write_reg(0xFF26, 0x80); // enable APU
+    apu.write_reg(0xFF1A, 0x80); // enable DAC
+    apu.write_reg(0xFF1E, 0x80); // trigger channel 3
+    assert_eq!(apu.read_reg(0xFF26) & 0x04, 0x04);
+    apu.write_reg(0xFF1A, 0x00); // disable DAC
+    assert_eq!(apu.read_reg(0xFF26) & 0x04, 0x00);
+}


### PR DESCRIPTION
## Summary
- disable wave channel when NR30 turns off DAC
- test that NR30 bit 7 immediately clears the channel active bit

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_688552af008c8325a546c8348d17d7f5