### PR TITLE
Add tests for NR33/NR34 and expose wave frequency

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -1051,6 +1051,16 @@ impl Apu {
     pub fn ch3_length(&self) -> u16 {
         self.ch3.length
     }
+
+    /// Current frequency setting for channel 3.
+    pub fn ch3_frequency(&self) -> u16 {
+        self.ch3.frequency
+    }
+
+    /// Current period timer for channel 3.
+    pub fn ch3_timer(&self) -> i32 {
+        self.ch3.timer
+    }
 }
 
 impl Default for Apu {


### PR DESCRIPTION
## Summary
- expose Channel 3 frequency and timer accessors
- add unit tests for NR33/NR34 behavior
- verify delayed period update and length/trigger semantics

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_6885658733a883259613eb10a509f439