### PR TITLE
Fix clippy warning

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1390,7 +1390,7 @@ impl Cpu {
                     }
                     | if self.a < val { FLAG_C } else { 0 };
             }
-            _ => panic!("unhandled opcode {:02X}", opcode),
+            _ => panic!("unhandled opcode {opcode:02X}"),
         }
 
         if enable_after {


### PR DESCRIPTION
## Summary
- fix panic format string

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_6885a679ea3883258fd85a7994dca7a1