### PR TITLE
Fix clippy uninlined args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -640,7 +640,7 @@ fn main() {
                                 if b.is_ascii_graphic() || *b == b' ' {
                                     print!("{}", *b as char);
                                 } else {
-                                    print!("\\x{:02X}", b);
+                                    print!("\\x{b:02X}");
                                 }
                             }
                             println!();
@@ -690,7 +690,7 @@ fn main() {
                         if b.is_ascii_graphic() || *b == b' ' {
                             print!("{}", *b as char);
                         } else {
-                            print!("\\x{:02X}", b);
+                            print!("\\x{b:02X}");
                         }
                     }
                     println!();

--- a/src/ui/vram_viewer.rs
+++ b/src/ui/vram_viewer.rs
@@ -559,7 +559,7 @@ impl VramViewerWindow {
         let draw_list = ui.get_window_draw_list();
         for row in 0..16 {
             let label = if row < 8 {
-                format!("BG{}", row)
+                format!("BG{row}")
             } else {
                 format!("OBJ{}", row - 8)
             };


### PR DESCRIPTION
## Summary
- inline format args in VRAM viewer and serial printer
- run `cargo fmt`, `cargo clippy`, and `cargo test` in debug and release

## Testing
- `cargo clippy`
- `cargo test`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_6885a97753588325a5fa6bdd647adb05