### PR TITLE
apu: enforce DAC state on channel triggers

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -778,7 +778,7 @@ impl Apu {
         ch.timer = ((new_timer & !0x3) | low_phase) + 1;
         ch.pending_reset = true;
         ch.first_sample = true;
-        ch.enabled = true;
+        ch.enabled = ch.dac_enabled;
         ch.envelope.volume = ch.envelope.initial;
         let mut freq_updated = false;
         if idx == 1 {
@@ -812,7 +812,7 @@ impl Apu {
     }
 
     fn trigger_wave(&mut self) {
-        self.ch3.enabled = true;
+        self.ch3.enabled = self.ch3.dac_enabled;
         self.ch3.position = 0;
         self.ch3.timer = self.ch3.period();
         if self.ch3.length == 0 {
@@ -827,7 +827,7 @@ impl Apu {
     }
 
     fn trigger_noise(&mut self) {
-        self.ch4.enabled = true;
+        self.ch4.enabled = self.ch4.dac_enabled;
         self.ch4.lfsr = 0x7FFF;
         self.ch4.timer = self.ch4.period();
         self.ch4.envelope.volume = self.ch4.envelope.initial;

--- a/tests/channel_activation.rs
+++ b/tests/channel_activation.rs
@@ -1,0 +1,56 @@
+use vibeEmu::apu::Apu;
+
+fn tick_machine(apu: &mut Apu, div: &mut u16, cycles: u16) {
+    let prev = *div;
+    *div = div.wrapping_add(cycles);
+    apu.tick(prev, *div, false);
+    apu.step(cycles);
+}
+
+#[test]
+fn channel1_triggers_when_dac_on() {
+    let mut apu = Apu::new();
+    apu.write_reg(0xFF26, 0x80); // enable APU
+    apu.write_reg(0xFF12, 0xF0); // DAC on
+    apu.write_reg(0xFF14, 0x80); // trigger channel 1
+    assert_eq!(apu.read_reg(0xFF26) & 0x01, 0x01);
+}
+
+#[test]
+fn channel1_trigger_ignored_when_dac_off() {
+    let mut apu = Apu::new();
+    apu.write_reg(0xFF26, 0x80); // enable APU
+    apu.write_reg(0xFF12, 0x00); // DAC off
+    apu.write_reg(0xFF14, 0x80); // attempt trigger
+    assert_eq!(apu.read_reg(0xFF26) & 0x01, 0x00);
+}
+
+#[test]
+fn channel1_disabled_by_length_timer() {
+    let mut apu = Apu::new();
+    apu.write_reg(0xFF26, 0x80);
+    apu.write_reg(0xFF11, 0x3F); // length = 1
+    apu.write_reg(0xFF12, 0xF0); // DAC on
+    apu.write_reg(0xFF14, 0x80); // trigger, length disabled
+    assert_eq!(apu.read_reg(0xFF26) & 0x01, 0x01);
+    let mut div = 0u16;
+    for _ in 0..(8192 / 4) {
+        tick_machine(&mut apu, &mut div, 4);
+    }
+    apu.write_reg(0xFF14, 0x40); // enable length
+    for _ in 0..(2 * 8192 / 4) {
+        tick_machine(&mut apu, &mut div, 4);
+    }
+    assert_eq!(apu.read_reg(0xFF26) & 0x01, 0x00);
+}
+
+#[test]
+fn sweep_overflow_disables_channel1() {
+    let mut apu = Apu::new();
+    apu.write_reg(0xFF26, 0x80);
+    apu.write_reg(0xFF10, 0x01); // period=0, shift=1 (addition)
+    apu.write_reg(0xFF12, 0xF0);
+    apu.write_reg(0xFF13, 0xF8);
+    apu.write_reg(0xFF14, 0x87); // high bits=7, trigger -> overflow
+    assert_eq!(apu.read_reg(0xFF26) & 0x01, 0x00);
+}


### PR DESCRIPTION
## Summary
- ensure channels only enable when DACs are on
- add regression tests for channel activation and deactivation

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`
- `cargo test --release --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6885b16ab4a88325b2f924610a8656ee