### PR TITLE
Add GTK build deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libx11-dev build-essential pkg-config libfontconfig1-dev
+          sudo apt-get install -y libasound2-dev libx11-dev libgtk-3-dev build-essential pkg-config libfontconfig1-dev
 
       - name: Cache rustup (optional)
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ cargo build
 
 The frontend uses `winit` with the `pixels` crate for window creation and
 rendering via `wgpu`. On Linux you may need X11 development packages installed
-(e.g. `libx11-dev`). Audio output relies on `cpal`, which requires ALSA
-headers. Install `libasound2-dev` as well if you build on Linux.
+(e.g. `libx11-dev`) and GTK development headers (`libgtk-3-dev`). Audio output
+relies on `cpal`, which requires ALSA headers. Install `libasound2-dev` as well
+if you build on Linux.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- install libgtk-3-dev on Linux CI builds
- document libgtk-3-dev as a requirement

## Testing
- `cargo clippy -- -D warnings`
- `cargo test -- -q`
- `cargo test --release -- -q`

------
https://chatgpt.com/codex/tasks/task_e_68864934f41883259b7d0562a5dccc55