### PR TITLE
Add TAC frequency tests

### DIFF
--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -291,7 +291,7 @@ fn stop_speed_switch_resets_div() {
 fn div_rate_double_speed() {
     // STOP for speed switch then 128 NOPs
     let mut program = vec![0x10, 0x00];
-    program.extend(std::iter::repeat(0x00).take(128));
+    program.extend(std::iter::repeat_n(0x00, 128));
     let mut cpu = Cpu::new();
     cpu.pc = 0;
     let mut mmu = Mmu::new_with_mode(true);

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -81,3 +81,36 @@ fn tma_write_same_cycle_overflow() {
     assert_eq!(t.tima, 0xAA); // old value should be loaded
     assert_eq!(if_reg & 0x04, 0x04);
 }
+
+#[test]
+fn tac_clock_select_262khz() {
+    let mut t = Timer::new();
+    let mut if_reg = 0u8;
+    // enable timer, freq 01 (262144 Hz -> bit 3)
+    t.write(0xFF07, 0x05, &mut if_reg);
+    t.step(16, &mut if_reg);
+    assert_eq!(t.tima, 1);
+    assert_eq!(if_reg, 0);
+}
+
+#[test]
+fn tac_clock_select_65khz() {
+    let mut t = Timer::new();
+    let mut if_reg = 0u8;
+    // enable timer, freq 10 (65536 Hz -> bit 5)
+    t.write(0xFF07, 0x06, &mut if_reg);
+    t.step(64, &mut if_reg);
+    assert_eq!(t.tima, 1);
+    assert_eq!(if_reg, 0);
+}
+
+#[test]
+fn tac_clock_select_16khz() {
+    let mut t = Timer::new();
+    let mut if_reg = 0u8;
+    // enable timer, freq 11 (16384 Hz -> bit 7)
+    t.write(0xFF07, 0x07, &mut if_reg);
+    t.step(256, &mut if_reg);
+    assert_eq!(t.tima, 1);
+    assert_eq!(if_reg, 0);
+}


### PR DESCRIPTION
## Summary
- cover all TAC clock select frequencies
- replace manual repeat with `repeat_n` for clippy

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
- `cargo test --quiet --release`


------
https://chatgpt.com/codex/tasks/task_e_688671c47468832590d475c94caa2eab