### PR TITLE
Add timer obscure behaviour tests

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -10,6 +10,10 @@ pub struct Timer {
     last_signal: bool,
     /// Previous value of TMA when a write occurred this cycle
     tma_latch: Option<u8>,
+    /// Value to reload TIMA with after an overflow delay
+    pending_reload: Option<u8>,
+    /// Delay before the pending reload is applied
+    reload_delay: u8,
 }
 
 impl Timer {
@@ -21,6 +25,8 @@ impl Timer {
             tac: 0,
             last_signal: false,
             tma_latch: None,
+            pending_reload: None,
+            reload_delay: 0,
         }
     }
 
@@ -39,12 +45,24 @@ impl Timer {
             0xFF04 => {
                 self.reset_div(if_reg);
             }
-            0xFF05 => self.tima = val,
+            0xFF05 => {
+                self.tima = val;
+                if self.pending_reload.is_some() && self.reload_delay > 0 {
+                    // writing during cycle A cancels the pending reload
+                    self.pending_reload = None;
+                    self.reload_delay = 0;
+                }
+                // writes during cycle B are ignored
+            }
             0xFF06 => {
                 // Store the old value so that if a reload occurs in the same
                 // cycle, the old value will be used.
                 self.tma_latch = Some(self.tma);
                 self.tma = val;
+                if self.pending_reload.is_some() && self.reload_delay == 0 {
+                    // update reload value when writing during cycle B
+                    self.pending_reload = Some(val);
+                }
             }
             0xFF07 => {
                 let prev = Self::signal_with(self.div, self.tac);
@@ -64,6 +82,15 @@ impl Timer {
     /// overflows.
     pub fn step(&mut self, cycles: u16, if_reg: &mut u8) {
         for _ in 0..cycles {
+            if let Some(val) = self.pending_reload {
+                if self.reload_delay == 0 {
+                    self.tima = val;
+                    *if_reg |= 0x04;
+                    self.pending_reload = None;
+                } else {
+                    self.reload_delay -= 1;
+                }
+            }
             let prev = self.last_signal;
             // Take any pending TMA write for this cycle
             let tma_old = self.tma_latch.take();
@@ -78,6 +105,15 @@ impl Timer {
 
     /// Reset the internal divider counter, applying TIMA edge logic.
     pub fn reset_div(&mut self, if_reg: &mut u8) {
+        if let Some(val) = self.pending_reload {
+            if self.reload_delay == 0 {
+                self.tima = val;
+                *if_reg |= 0x04;
+                self.pending_reload = None;
+            } else {
+                self.reload_delay -= 1;
+            }
+        }
         let prev = Self::signal_with(self.div, self.tac);
         self.div = 0;
         let new = Self::signal_with(self.div, self.tac);
@@ -88,10 +124,11 @@ impl Timer {
         self.last_signal = new;
     }
 
-    fn increment(&mut self, if_reg: &mut u8, tma_old: Option<u8>) {
+    fn increment(&mut self, _if_reg: &mut u8, tma_old: Option<u8>) {
         if self.tima == 0xFF {
-            self.tima = tma_old.unwrap_or(self.tma);
-            *if_reg |= 0x04;
+            self.tima = 0;
+            self.pending_reload = Some(tma_old.unwrap_or(self.tma));
+            self.reload_delay = 1;
         } else {
             self.tima = self.tima.wrapping_add(1);
         }


### PR DESCRIPTION
## Summary
- model delayed TIMA reload with new pending reload logic
- cancel or update reload when writing to TIMA/TMA mid-cycle
- add edge case tests for clock select changes and overflow behaviour

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --test timer --quiet`
- `cargo test --release --test timer --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688675b9b85c8325883894e0d260c041