### PR TITLE
Enable passing same suite delay tests

### DIFF
--- a/tests/same_suite.rs
+++ b/tests/same_suite.rs
@@ -103,7 +103,6 @@ fn same_suite__apu__channel_1__channel_1_align_cpu_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__apu__channel_1__channel_1_delay_gb() {
     const EXPECTED: [u8; 32] = [
         0x00, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x00, 0x00, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
@@ -331,7 +330,6 @@ fn same_suite__apu__channel_2__channel_2_align_cpu_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__apu__channel_2__channel_2_delay_gb() {
     let passed = run_same_suite(
         common::rom_path("same-suite/apu/channel_2/channel_2_delay.gb"),


### PR DESCRIPTION
## Summary
- leave the channel 1 and channel 2 delay scenarios in `tests/same_suite.rs` active now that they pass
- confirmed the other same suite and dmg sound rom tests still require `#[ignore]`

## Testing
- cargo test same_suite -- --nocapture *(fails; used to identify which same_suite cases still panic)*
- cargo test dmg_sound_ -- --nocapture *(fails; used to identify which dmg_sound cases still panic)*

------
https://chatgpt.com/codex/tasks/task_e_68c98fd3256c83259c5c2138a5935ad8