### PR TITLE
Fix square duty mapping for SameSuite test

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -187,10 +187,10 @@ impl SquareChannel {
             return 0;
         }
         const DUTY_TABLE: [[u8; 8]; 4] = [
-            [0, 1, 0, 0, 0, 0, 0, 0], // 12.5%
-            [0, 1, 1, 0, 0, 0, 0, 0], // 25%
+            [0, 0, 0, 1, 0, 0, 0, 0], // 12.5%
+            [0, 0, 0, 1, 1, 0, 0, 0], // 25%
             [0, 1, 1, 1, 1, 0, 0, 0], // 50%
-            [1, 0, 0, 1, 1, 1, 1, 1], // 75%
+            [1, 1, 1, 0, 0, 1, 1, 1], // 75%
         ];
         let level = DUTY_TABLE[self.duty as usize][self.duty_pos as usize];
         level * self.envelope.volume
@@ -221,10 +221,10 @@ impl SquareChannel {
             return 0;
         }
         const DUTY_TABLE: [[u8; 8]; 4] = [
-            [0, 1, 0, 0, 0, 0, 0, 0],
-            [0, 1, 1, 0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 1, 1, 0, 0, 0],
             [0, 1, 1, 1, 1, 0, 0, 0],
-            [1, 0, 0, 1, 1, 1, 1, 1],
+            [1, 1, 1, 0, 0, 1, 1, 1],
         ];
         let level = DUTY_TABLE[self.duty as usize][self.duty_pos as usize];
         level * self.envelope.volume
@@ -860,7 +860,7 @@ impl Apu {
         ch.timer = new_timer;
         ch.pending_reset = true;
         ch.first_sample = true;
-        ch.pcm_gate = sample_length * 4 + 4;
+        ch.pcm_gate = sample_length * 4 + 6;
         ch.out_stage1 = 0;
         ch.out_latched = 0;
         ch.enabled = ch.dac_enabled;


### PR DESCRIPTION
## Summary
- align the square channel duty lookup tables with SameSuite's expected phase mapping
- slightly extend the PCM gate to delay the first square sample long enough for the duty test

## Testing
- cargo test same_suite__apu__channel_1__channel_1_duty_gb -- --ignored --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68c9b812e9f483259f11f12f15d0995a