### PR TITLE
docs: enforce clippy warnings in agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,39 @@
 # AGENT Instructions
 
-This repository contains a small Game Boy emulator written in Rust. It is organized with a clear separation between the emulation core and platform-specific frontends, and follows the guidance laid out in the `TODO.md` at the root of the repository.
+This repository contains **vibeEmu**, a cycle-accurate Game Boy / Game Boy Color emulator written in Rust. The core emulation
+lives in `src/` (modules for the CPU, MMU, PPU, APU, timer, cartridge, input, serial, audio, and the `GameBoy` facade). The
+`src/ui/` module provides the `winit` + `pixels` frontend, while integration tests reside under `tests/`. Assets such as logos
+and screenshots live in `gfx/` and `extra_screenshots/`, and a patched copy of `imgui-wgpu` is vendored under `vendor/`.
 
-When making changes:
+## Before you write code
+- Read `README.md`, the relevant modules, and existing tests to understand the current architecture and command-line options.
+- Keep changes scoped to the subsystem you are improving. Coordinate updates that touch shared scheduling/state (e.g.
+  `gameboy.rs`, `hardware.rs`, or timing-critical code) to avoid regressions in other modules.
+- Maintain the separation between platform-agnostic emulator logic and platform-specific frontends. Windowing, input, and audio
+  plumbing should stay outside of the core emulation modules.
 
-- **Consult the TODO.md**: Always review `TODO.md` for module responsibilities, implementation priorities, and architectural guidelines before starting work.
-- **Modular development**: Assign each AI agent a single module or feature (e.g., CPU, PPU, APU, MMU, Cartridge/MBC, Timer, I/O). Ensure your PR only affects the intended module(s).
-- **Follow the design roadmap**: Implement modules in the order specified: project skeleton → cartridge loading → CPU core → MMU integration → PPU → APU → timer & interrupts → input/serial → frontend integration.
-- **Maintain cycle accuracy**: When coding core logic (CPU, PPU, APU, timer), verify timing against Pan Docs and Blargg test suites. Write unit tests for opcode timing, PPU mode durations, and APU frame sequencer steps.
-- **Adhere to style and tooling**:
-  - Format all Rust sources with `cargo fmt --all`.
-  - Lint with `cargo clippy` and address warnings before merging.
-  - Run `cargo test` in both debug and release profiles; ensure no failures.
-- **Front-end separation**: Decouple PPU frame buffer logic from rendering; use `minifb`, `pixels`, or `winit` + `pixels` for windowing. Keep core modules free of OS-specific calls.
-- **PR and commit guidelines**:
-  - Prefix commits with module name (e.g., `ppu: implement OAM scan`).
-  - Reference corresponding TODO.md task (e.g., `TODO.md #PPU: Mode 2 timing`).
-  - Include a summary of changes and any new tests or benchmarking results.
-- **Testing strategy**:
-  - Add unit tests for new functions or modules.
-  - Integrate Blargg and MooneyeGB test ROMs where applicable; document any unsupported quirks.
-  - Automate CI to run tests, benchmarks, and formatting checks.
-- **Documentation and comments**:
-  - Document public structs and methods with Rustdoc comments.
-  - Add `// TODO:` notes for incomplete behaviors, referencing the task in `TODO.md`.
-- **Continuous integration**:
-  - Ensure the CI pipeline installs dependencies (e.g., `libasound2-dev` for audio); when adding any new install dependencies, update the project’s setup documentation or scripts and note the change in your PR. Provide clear instructions on environment setup for future runs, then run builds, tests, and lints.
-  - Update workflow files when adding new crates or build steps.
+## Coding guidelines
+- Use idiomatic Rust (edition 2024). Document new public APIs with Rustdoc where it clarifies hardware behaviour and annotate
+  tricky timing or hardware quirks with inline comments.
+- If you add dependencies, update `Cargo.toml`, `Cargo.lock`, and any related documentation. Changes to vendored crates should be
+  isolated to `vendor/` with a clear explanation of why the patch is necessary.
+- Update documentation or CLI help when you change user-facing behaviour.
 
-By following these instructions, AI agents will maintain code quality, consistency with the project's architecture, and alignment with the comprehensive guidance in `TODO.md`. Merge only after all checks pass and a core maintainer review is complete.
+## Testing & tooling
+Run the full suite whenever you touch Rust code or modify build configuration:
+1. `cargo fmt --all`
+2. `cargo clippy --workspace --all-targets -- -D warnings`
+3. `cargo test`
+4. `cargo test --release`
 
+Integration tests automatically download required ROM bundles into `test_roms/` on first run; ensure network access is available
+and leave the archive intact for subsequent runs. Investigate failing third-party ROMs instead of deleting or disabling tests.
+
+## Additional expectations
+- Add or update unit/integration tests when fixing bugs or introducing behaviour, especially around CPU/APU/PPU timing and other
+  hardware edge cases.
+- Keep commits and PRs focused, and use descriptive prefixes such as `ppu: fix mode 3 timing`. Reference the tests you ran in the
+  PR description.
+- Preserve determinism where possible—avoid introducing sources of randomness that would break reproducibility.
+
+Following these guidelines keeps vibeEmu maintainable, accurate, and easy for future contributors to navigate.


### PR DESCRIPTION
## Summary
- remove the stale screenshot reminder from the contributor guidance
- require contributors to run `cargo clippy --workspace --all-targets -- -D warnings`

## Testing
- cargo clippy --workspace --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68d18bf221e08325b4cf7a4938e91c34