### PR TITLE
Fix BGPI/OBPI register invariants

### DIFF
--- a/tests/same_suite.rs
+++ b/tests/same_suite.rs
@@ -850,7 +850,6 @@ fn same_suite__interrupt__ei_delay_halt_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__ppu__blocking_bgpi_increase_gb() {
     let passed = run_same_suite(
         common::rom_path("same-suite/ppu/blocking_bgpi_increase.gb"),


### PR DESCRIPTION
## Summary
- ensure BG and OBJ palette index registers maintain bit 6 set internally and centralize auto-increment handling to match hardware behavior
- enable SameSuite blocking BGPI increase regression test in the default suite

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features
- cargo test
- cargo test --release

------
https://chatgpt.com/codex/tasks/task_e_68d1a05330cc8325bf63f261f8b7fda7