### PR TITLE
Fix clippy manual-is-multiple-of warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -639,7 +639,7 @@ fn main() {
                         win.win.request_redraw();
                     }
 
-                    if args.debug && frame_count % 60 == 0 {
+                    if args.debug && frame_count.is_multiple_of(60) {
                         let serial = gb.mmu.take_serial();
                         if !serial.is_empty() {
                             print!("[SERIAL] ");
@@ -689,7 +689,7 @@ fn main() {
             frame.copy_from_slice(gb.mmu.ppu.framebuffer());
             gb.mmu.ppu.clear_frame_flag();
 
-            if args.debug && frame_count % 60 == 0 {
+            if args.debug && frame_count.is_multiple_of(60) {
                 let serial = gb.mmu.take_serial();
                 if !serial.is_empty() {
                     print!("[SERIAL] ");

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -353,10 +353,12 @@ impl Mmu {
             }
 
             let elapsed = 640 - self.dma_cycles;
-            if elapsed % 4 == 0 && elapsed / 4 < 0xA0 {
+            if elapsed.is_multiple_of(4) {
                 let idx: u16 = elapsed / 4;
-                let byte = self.dma_read_byte(self.dma_source.wrapping_add(idx));
-                self.ppu.oam[idx as usize] = byte;
+                if idx < 0xA0 {
+                    let byte = self.dma_read_byte(self.dma_source.wrapping_add(idx));
+                    self.ppu.oam[idx as usize] = byte;
+                }
             }
 
             self.dma_cycles -= 1;


### PR DESCRIPTION
## Summary
- replace manual modulo checks with `is_multiple_of` in the DMA and debug logging paths
- guard the DMA indexing logic with the existing 0xA0 limit after switching to `is_multiple_of`

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release

------
https://chatgpt.com/codex/tasks/task_e_68d1e27383b48325bf7fedd2b1931a04