### PR TITLE
dma: run first hdma block immediately in hblank

### DIFF
--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -33,10 +33,10 @@ Combined exit code: 101
 
 | Category | Passed | Failed | Ignored | Measured | Total | Pass % |
 | --- | --- | --- | --- | --- | --- | --- |
-| ROM Test Suites | 104 | 81 | 0 | 0 | 185 | 56.2% |
+| ROM Test Suites | 105 | 80 | 0 | 0 | 185 | 56.8% |
 | Integration Tests | 156 | 18 | 0 | 0 | 174 | 89.7% |
 | Unit Tests | 5 | 0 | 0 | 0 | 5 | 100.0% |
-| **Overall** | 265 | 99 | 0 | 0 | 364 | 72.8% |
+| **Overall** | 266 | 98 | 0 | 0 | 364 | 73.1% |
 
 ## Failing Tests
 
@@ -133,7 +133,6 @@ Combined exit code: 101
 - `same_suite__apu__div_write_trigger_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__apu__div_write_trigger_volume_10_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__apu__div_write_trigger_volume_gb` _(Category: ROM Test Suites; Module: same_suite)_
-- `same_suite__dma__gdma_addr_mask_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__dma__hdma_lcd_off_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__dma__hdma_mode0_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__interrupt__ei_delay_halt_gb` _(Category: ROM Test Suites; Module: same_suite)_
@@ -296,7 +295,7 @@ Combined exit code: 101
 | `timer__tima_write_reloading_gb` | ❌ Fail |
 | `timer__tma_write_reloading_gb` | ❌ Fail |
 
-#### same_suite (31/78 passing, 39.7%)
+#### same_suite (32/78 passing, 41.0%)
 
 | Test | Result |
 | --- | --- |
@@ -330,6 +329,7 @@ Combined exit code: 101
 | `same_suite__apu__channel_3__channel_3_stop_delay_gb` | ✅ Pass |
 | `same_suite__apu__channel_3__channel_3_wave_ram_dac_on_rw_gb` | ✅ Pass |
 | `same_suite__dma__gbc_dma_cont_gb` | ✅ Pass |
+| `same_suite__dma__gdma_addr_mask_gb` | ✅ Pass |
 | `same_suite__ppu__blocking_bgpi_increase_gb` | ✅ Pass |
 | `same_suite__apu__channel_1__channel_1_extra_length_clocking_cgb0B_gb` | ❌ Fail |
 | `same_suite__apu__channel_1__channel_1_freq_change_timing_cgb0BC_gb` | ❌ Fail |
@@ -372,7 +372,6 @@ Combined exit code: 101
 | `same_suite__apu__div_write_trigger_gb` | ❌ Fail |
 | `same_suite__apu__div_write_trigger_volume_10_gb` | ❌ Fail |
 | `same_suite__apu__div_write_trigger_volume_gb` | ❌ Fail |
-| `same_suite__dma__gdma_addr_mask_gb` | ❌ Fail |
 | `same_suite__dma__hdma_lcd_off_gb` | ❌ Fail |
 | `same_suite__dma__hdma_mode0_gb` | ❌ Fail |
 | `same_suite__interrupt__ei_delay_halt_gb` | ❌ Fail |

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -294,6 +294,9 @@ impl Mmu {
                     self.hdma.mode = DmaMode::Hdma;
                     self.hdma.blocks = requested_blocks;
                     self.hdma.active = true;
+                    if self.ppu.in_hblank() {
+                        self.hdma_hblank_transfer();
+                    }
                 }
             }
             0xFF4D => {

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -167,6 +167,10 @@ impl Ppu {
         Self::new_with_mode(false)
     }
 
+    pub fn in_hblank(&self) -> bool {
+        self.mode == MODE_HBLANK
+    }
+
     fn decode_cgb_color(lo: u8, hi: u8) -> u32 {
         let raw = ((hi as u16) << 8) | lo as u16;
         let r = ((raw & 0x1F) as u8) << 3 | ((raw & 0x1F) as u8 >> 2);

--- a/tests/same_suite.rs
+++ b/tests/same_suite.rs
@@ -813,7 +813,6 @@ fn same_suite__dma__gbc_dma_cont_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__dma__gdma_addr_mask_gb() {
     let passed = run_same_suite(
         common::rom_path("same-suite/dma/gdma_addr_mask.gb"),


### PR DESCRIPTION
## Summary
- trigger the first HDMA block immediately when the PPU is already in HBlank so LCD-off HDMA requests copy data
- expose a `Ppu::in_hblank` helper used by the MMU to detect the appropriate mode
- re-enable the gdma address mask SameSuite test and refresh TEST_STATUS.md

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d204dcc7308325984fdb37664ac156