### PR TITLE
dma: report HDMA status correctly

### DIFF
--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -33,10 +33,10 @@ Combined exit code: 101
 
 | Category | Passed | Failed | Ignored | Measured | Total | Pass % |
 | --- | --- | --- | --- | --- | --- | --- |
-| ROM Test Suites | 105 | 80 | 0 | 0 | 185 | 56.8% |
+| ROM Test Suites | 107 | 78 | 0 | 0 | 185 | 57.8% |
 | Integration Tests | 156 | 18 | 0 | 0 | 174 | 89.7% |
 | Unit Tests | 5 | 0 | 0 | 0 | 5 | 100.0% |
-| **Overall** | 266 | 98 | 0 | 0 | 364 | 73.1% |
+| **Overall** | 268 | 96 | 0 | 0 | 364 | 73.6% |
 
 ## Failing Tests
 
@@ -133,8 +133,6 @@ Combined exit code: 101
 - `same_suite__apu__div_write_trigger_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__apu__div_write_trigger_volume_10_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__apu__div_write_trigger_volume_gb` _(Category: ROM Test Suites; Module: same_suite)_
-- `same_suite__dma__hdma_lcd_off_gb` _(Category: ROM Test Suites; Module: same_suite)_
-- `same_suite__dma__hdma_mode0_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__interrupt__ei_delay_halt_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__sgb__command_mlt_req_1_incrementing_gb` _(Category: ROM Test Suites; Module: same_suite)_
 - `same_suite__sgb__command_mlt_req_gb` _(Category: ROM Test Suites; Module: same_suite)_
@@ -295,7 +293,7 @@ Combined exit code: 101
 | `timer__tima_write_reloading_gb` | ❌ Fail |
 | `timer__tma_write_reloading_gb` | ❌ Fail |
 
-#### same_suite (32/78 passing, 41.0%)
+#### same_suite (34/78 passing, 43.6%)
 
 | Test | Result |
 | --- | --- |
@@ -330,6 +328,8 @@ Combined exit code: 101
 | `same_suite__apu__channel_3__channel_3_wave_ram_dac_on_rw_gb` | ✅ Pass |
 | `same_suite__dma__gbc_dma_cont_gb` | ✅ Pass |
 | `same_suite__dma__gdma_addr_mask_gb` | ✅ Pass |
+| `same_suite__dma__hdma_lcd_off_gb` | ✅ Pass |
+| `same_suite__dma__hdma_mode0_gb` | ✅ Pass |
 | `same_suite__ppu__blocking_bgpi_increase_gb` | ✅ Pass |
 | `same_suite__apu__channel_1__channel_1_extra_length_clocking_cgb0B_gb` | ❌ Fail |
 | `same_suite__apu__channel_1__channel_1_freq_change_timing_cgb0BC_gb` | ❌ Fail |
@@ -372,8 +372,6 @@ Combined exit code: 101
 | `same_suite__apu__div_write_trigger_gb` | ❌ Fail |
 | `same_suite__apu__div_write_trigger_volume_10_gb` | ❌ Fail |
 | `same_suite__apu__div_write_trigger_volume_gb` | ❌ Fail |
-| `same_suite__dma__hdma_lcd_off_gb` | ❌ Fail |
-| `same_suite__dma__hdma_mode0_gb` | ❌ Fail |
 | `same_suite__interrupt__ei_delay_halt_gb` | ❌ Fail |
 | `same_suite__sgb__command_mlt_req_1_incrementing_gb` | ❌ Fail |
 | `same_suite__sgb__command_mlt_req_gb` | ❌ Fail |

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -176,8 +176,11 @@ impl Mmu {
             0xFF53 => ((self.hdma.dst & 0x1F00) >> 8) as u8,
             0xFF54 => (self.hdma.dst & 0x00F0) as u8,
             0xFF55 => {
+                let remaining = self.hdma.blocks.saturating_sub(1) & 0x7F;
                 if self.hdma.active {
-                    (self.hdma.blocks.saturating_sub(1)) | 0x80
+                    remaining
+                } else if self.hdma.mode == DmaMode::Hdma {
+                    remaining | 0x80
                 } else {
                     0xFF
                 }

--- a/tests/same_suite.rs
+++ b/tests/same_suite.rs
@@ -822,7 +822,6 @@ fn same_suite__dma__gdma_addr_mask_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__dma__hdma_lcd_off_gb() {
     let passed = run_same_suite(
         common::rom_path("same-suite/dma/hdma_lcd_off.gb"),
@@ -832,7 +831,6 @@ fn same_suite__dma__hdma_lcd_off_gb() {
 }
 
 #[test]
-#[ignore]
 fn same_suite__dma__hdma_mode0_gb() {
     let passed = run_same_suite(common::rom_path("same-suite/dma/hdma_mode0.gb"), 20_000_000);
     assert!(passed, "test failed");


### PR DESCRIPTION
## Summary
- ensure FF55 returns the remaining HDMA block count with the correct active bit state
- un-ignore the SameSuite HDMA LCD-off and mode0 tests now that they pass and refresh TEST_STATUS.md

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py


------
https://chatgpt.com/codex/tasks/task_e_68d20beeb2e88325b51f4fe132fd717c