### PR TITLE
hardware: add dmg revisions for boot regs

### DIFF
--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -33,10 +33,10 @@ Combined exit code: 101
 
 | Category | Passed | Failed | Ignored | Measured | Total | Pass % |
 | --- | --- | --- | --- | --- | --- | --- |
-| ROM Test Suites | 108 | 77 | 0 | 0 | 185 | 58.4% |
+| ROM Test Suites | 109 | 76 | 0 | 0 | 185 | 58.9% |
 | Integration Tests | 156 | 18 | 0 | 0 | 174 | 89.7% |
 | Unit Tests | 5 | 0 | 0 | 0 | 5 | 100.0% |
-| **Overall** | 269 | 95 | 0 | 0 | 364 | 73.9% |
+| **Overall** | 270 | 94 | 0 | 0 | 364 | 74.2% |
 
 ## Failing Tests
 
@@ -75,7 +75,6 @@ Combined exit code: 101
 - `boot_hwio_S_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_hwio_dmg0_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_hwio_dmgABCmgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
-- `boot_regs_dmg0_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_mgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_sgb2_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_sgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
@@ -212,13 +211,14 @@ Combined exit code: 101
 | `mem_timing_read` | ✅ Pass |
 | `mem_timing_write` | ✅ Pass |
 
-#### mooneye_acceptance (50/75 passing, 66.7%)
+#### mooneye_acceptance (51/75 passing, 68.0%)
 
 | Test | Result |
 | --- | --- |
 | `add_sp_e_timing_gb` | ✅ Pass |
 | `bits__mem_oam_gb` | ✅ Pass |
 | `bits__reg_f_gb` | ✅ Pass |
+| `boot_regs_dmg0_gb` | ✅ Pass |
 | `boot_regs_dmgABC_gb` | ✅ Pass |
 | `call_cc_timing2_gb` | ✅ Pass |
 | `call_cc_timing_gb` | ✅ Pass |
@@ -274,7 +274,6 @@ Combined exit code: 101
 | `boot_hwio_S_gb` | ❌ Fail |
 | `boot_hwio_dmg0_gb` | ❌ Fail |
 | `boot_hwio_dmgABCmgb_gb` | ❌ Fail |
-| `boot_regs_dmg0_gb` | ❌ Fail |
 | `boot_regs_mgb_gb` | ❌ Fail |
 | `boot_regs_sgb2_gb` | ❌ Fail |
 | `boot_regs_sgb_gb` | ❌ Fail |

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -1,9 +1,14 @@
-use crate::{cpu::Cpu, hardware::CgbRevision, mmu::Mmu};
+use crate::{
+    cpu::Cpu,
+    hardware::{CgbRevision, DmgRevision},
+    mmu::Mmu,
+};
 
 pub struct GameBoy {
     pub cpu: Cpu,
     pub mmu: Mmu,
     pub cgb: bool,
+    pub dmg_revision: DmgRevision,
     pub cgb_revision: CgbRevision,
 }
 
@@ -13,15 +18,24 @@ impl GameBoy {
     }
 
     pub fn new_with_mode(cgb: bool) -> Self {
-        Self::new_with_revision(cgb, CgbRevision::default())
+        Self::new_with_revisions(cgb, DmgRevision::default(), CgbRevision::default())
     }
 
     pub fn new_with_revision(cgb: bool, revision: CgbRevision) -> Self {
+        Self::new_with_revisions(cgb, DmgRevision::default(), revision)
+    }
+
+    pub fn new_with_revisions(
+        cgb: bool,
+        dmg_revision: DmgRevision,
+        cgb_revision: CgbRevision,
+    ) -> Self {
         Self {
-            cpu: Cpu::new_with_mode(cgb),
-            mmu: Mmu::new_with_config(cgb, revision),
+            cpu: Cpu::new_with_mode_and_revision(cgb, dmg_revision),
+            mmu: Mmu::new_with_config(cgb, cgb_revision),
             cgb,
-            cgb_revision: revision,
+            dmg_revision,
+            cgb_revision,
         }
     }
 
@@ -30,7 +44,7 @@ impl GameBoy {
     pub fn reset(&mut self) {
         let cart = self.mmu.cart.take();
         let boot = self.mmu.boot_rom.take();
-        self.cpu = Cpu::new_with_mode(self.cgb);
+        self.cpu = Cpu::new_with_mode_and_revision(self.cgb, self.dmg_revision);
         self.mmu = Mmu::new_with_config(self.cgb, self.cgb_revision);
         if let Some(c) = cart {
             self.mmu.load_cart(c);

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -1,4 +1,13 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum DmgRevision {
+    Rev0,
+    RevA,
+    RevB,
+    #[default]
+    RevC,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum CgbRevision {
     Rev0,
     RevA,


### PR DESCRIPTION
## Summary
- add a `DmgRevision` enum with RevC as the default
- initialize DMG boot registers based on the requested revision and plumb it through `GameBoy`
- allow the `boot_regs_dmg0_gb` acceptance test to force DMG Rev0 and refresh `TEST_STATUS.md`

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d295d6b42883259dfcbada2847a0c5