### PR TITLE
ppu/mmu: model DMG boot HWIO state

### DIFF
--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -33,10 +33,10 @@ Combined exit code: 101
 
 | Category | Passed | Failed | Ignored | Measured | Total | Pass % |
 | --- | --- | --- | --- | --- | --- | --- |
-| ROM Test Suites | 109 | 76 | 0 | 0 | 185 | 58.9% |
+| ROM Test Suites | 111 | 74 | 0 | 0 | 185 | 60.0% |
 | Integration Tests | 156 | 18 | 0 | 0 | 174 | 89.7% |
 | Unit Tests | 5 | 0 | 0 | 0 | 5 | 100.0% |
-| **Overall** | 270 | 94 | 0 | 0 | 364 | 74.2% |
+| **Overall** | 272 | 92 | 0 | 0 | 364 | 74.7% |
 
 ## Failing Tests
 
@@ -73,8 +73,6 @@ Combined exit code: 101
 - `boot_div_dmg0_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_div_dmgABCmgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_hwio_S_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
-- `boot_hwio_dmg0_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
-- `boot_hwio_dmgABCmgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_mgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_sgb2_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_sgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
@@ -211,13 +209,15 @@ Combined exit code: 101
 | `mem_timing_read` | ✅ Pass |
 | `mem_timing_write` | ✅ Pass |
 
-#### mooneye_acceptance (51/75 passing, 68.0%)
+#### mooneye_acceptance (53/75 passing, 70.7%)
 
 | Test | Result |
 | --- | --- |
 | `add_sp_e_timing_gb` | ✅ Pass |
 | `bits__mem_oam_gb` | ✅ Pass |
 | `bits__reg_f_gb` | ✅ Pass |
+| `boot_hwio_dmg0_gb` | ✅ Pass |
+| `boot_hwio_dmgABCmgb_gb` | ✅ Pass |
 | `boot_regs_dmg0_gb` | ✅ Pass |
 | `boot_regs_dmgABC_gb` | ✅ Pass |
 | `call_cc_timing2_gb` | ✅ Pass |
@@ -272,8 +272,6 @@ Combined exit code: 101
 | `boot_div_dmg0_gb` | ❌ Fail |
 | `boot_div_dmgABCmgb_gb` | ❌ Fail |
 | `boot_hwio_S_gb` | ❌ Fail |
-| `boot_hwio_dmg0_gb` | ❌ Fail |
-| `boot_hwio_dmgABCmgb_gb` | ❌ Fail |
 | `boot_regs_mgb_gb` | ❌ Fail |
 | `boot_regs_sgb2_gb` | ❌ Fail |
 | `boot_regs_sgb_gb` | ❌ Fail |

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -32,7 +32,7 @@ impl GameBoy {
     ) -> Self {
         Self {
             cpu: Cpu::new_with_mode_and_revision(cgb, dmg_revision),
-            mmu: Mmu::new_with_config(cgb, cgb_revision),
+            mmu: Mmu::new_with_revisions(cgb, dmg_revision, cgb_revision),
             cgb,
             dmg_revision,
             cgb_revision,
@@ -45,7 +45,7 @@ impl GameBoy {
         let cart = self.mmu.cart.take();
         let boot = self.mmu.boot_rom.take();
         self.cpu = Cpu::new_with_mode_and_revision(self.cgb, self.dmg_revision);
-        self.mmu = Mmu::new_with_config(self.cgb, self.cgb_revision);
+        self.mmu = Mmu::new_with_revisions(self.cgb, self.dmg_revision, self.cgb_revision);
         if let Some(c) = cart {
             self.mmu.load_cart(c);
         }

--- a/tests/mmu.rs
+++ b/tests/mmu.rs
@@ -2,7 +2,7 @@ use vibeEmu::{cartridge::Cartridge, mmu::Mmu};
 
 #[test]
 fn wram_echo_and_bank_switch() {
-    let mut mmu = Mmu::new();
+    let mut mmu = Mmu::new_with_mode(true);
     mmu.write_byte(0xC000, 0xAA);
     assert_eq!(mmu.read_byte(0xC000), 0xAA);
     mmu.write_byte(0xE000, 0xBB);
@@ -23,7 +23,7 @@ fn wram_echo_and_bank_switch() {
 
 #[test]
 fn vram_bank_switch() {
-    let mut mmu = Mmu::new();
+    let mut mmu = Mmu::new_with_mode(true);
     mmu.write_byte(0x8000, 0x11);
     assert_eq!(mmu.read_byte(0x8000), 0x11);
 

--- a/tests/mooneye_acceptance.rs
+++ b/tests/mooneye_acceptance.rs
@@ -117,21 +117,21 @@ fn boot_hwio_S_gb() {
 }
 
 #[test]
-#[ignore]
 fn boot_hwio_dmg0_gb() {
-    let passed = run_mooneye_acceptance(
+    let passed = run_mooneye_acceptance_with_dmg_revision(
         common::rom_path("mooneye-test-suite/acceptance/boot_hwio-dmg0.gb"),
         20_000_000,
+        DmgRevision::Rev0,
     );
     assert!(passed, "test failed");
 }
 
 #[test]
-#[ignore]
 fn boot_hwio_dmgABCmgb_gb() {
-    let passed = run_mooneye_acceptance(
+    let passed = run_mooneye_acceptance_with_dmg_revision(
         common::rom_path("mooneye-test-suite/acceptance/boot_hwio-dmgABCmgb.gb"),
         20_000_000,
+        DmgRevision::RevC,
     );
     assert!(passed, "test failed");
 }

--- a/tests/ppu.rs
+++ b/tests/ppu.rs
@@ -2,7 +2,7 @@ use vibeEmu::ppu::Ppu;
 
 #[test]
 fn register_access() {
-    let mut ppu = Ppu::new();
+    let mut ppu = Ppu::new_with_mode(true);
     ppu.write_reg(0xFF40, 0x91);
     ppu.write_reg(0xFF47, 0xFC);
     ppu.write_reg(0xFF4A, 0x01);


### PR DESCRIPTION
## Summary
- thread the selected DMG revision into the MMU/PPU so the timer seed, STAT/LY boot state, and boot hold timing match real hardware
- guard CGB-only hardware registers so DMG mode returns open bus values and ignores writes
- exercise the new paths by running the Mooneye boot HWIO tests with the correct revisions and update `TEST_STATUS.md`

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py


------
https://chatgpt.com/codex/tasks/task_e_68d2bb8bb78c832585e5056e65bb33af