### PR TITLE
mmu: mirror OAM DMA high RAM sources

### DIFF
--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -33,10 +33,10 @@ Combined exit code: 101
 
 | Category | Passed | Failed | Ignored | Measured | Total | Pass % |
 | --- | --- | --- | --- | --- | --- | --- |
-| ROM Test Suites | 113 | 72 | 0 | 0 | 185 | 61.1% |
+| ROM Test Suites | 114 | 71 | 0 | 0 | 185 | 61.6% |
 | Integration Tests | 156 | 18 | 0 | 0 | 174 | 89.7% |
 | Unit Tests | 5 | 0 | 0 | 0 | 5 | 100.0% |
-| **Overall** | 274 | 90 | 0 | 0 | 364 | 75.3% |
+| **Overall** | 275 | 89 | 0 | 0 | 364 | 75.5% |
 
 ## Failing Tests
 
@@ -76,7 +76,6 @@ Combined exit code: 101
 - `boot_regs_mgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_sgb2_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_sgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
-- `oam_dma__sources_GS_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `ppu__hblank_ly_scx_timing_GS_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `ppu__intr_2_mode0_timing_sprites_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `ppu__lcdon_timing_GS_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
@@ -207,7 +206,7 @@ Combined exit code: 101
 | `mem_timing_read` | ✅ Pass |
 | `mem_timing_write` | ✅ Pass |
 
-#### mooneye_acceptance (55/75 passing, 73.3%)
+#### mooneye_acceptance (56/75 passing, 74.7%)
 
 | Test | Result |
 | --- | --- |
@@ -239,6 +238,7 @@ Combined exit code: 101
 | `ld_hl_sp_e_timing_gb` | ✅ Pass |
 | `oam_dma__basic_gb` | ✅ Pass |
 | `oam_dma__reg_read_gb` | ✅ Pass |
+| `oam_dma__sources_GS_gb` | ✅ Pass |
 | `oam_dma_restart_gb` | ✅ Pass |
 | `oam_dma_start_gb` | ✅ Pass |
 | `oam_dma_timing_gb` | ✅ Pass |
@@ -275,7 +275,6 @@ Combined exit code: 101
 | `boot_regs_mgb_gb` | ❌ Fail |
 | `boot_regs_sgb2_gb` | ❌ Fail |
 | `boot_regs_sgb_gb` | ❌ Fail |
-| `oam_dma__sources_GS_gb` | ❌ Fail |
 | `ppu__hblank_ly_scx_timing_GS_gb` | ❌ Fail |
 | `ppu__intr_2_mode0_timing_sprites_gb` | ❌ Fail |
 | `ppu__lcdon_timing_GS_gb` | ❌ Fail |

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -277,6 +277,12 @@ impl Mmu {
     }
 
     fn dma_read_byte(&mut self, addr: u16) -> u8 {
+        let addr = if !self.cgb_mode && (0xFE00..=0xFF9F).contains(&addr) {
+            addr.wrapping_sub(0x2000)
+        } else {
+            addr
+        };
+
         self.read_byte_inner(addr, true)
     }
 

--- a/tests/mooneye_acceptance.rs
+++ b/tests/mooneye_acceptance.rs
@@ -376,7 +376,6 @@ fn oam_dma__reg_read_gb() {
 }
 
 #[test]
-#[ignore]
 fn oam_dma__sources_GS_gb() {
     let passed = run_mooneye_acceptance(
         common::rom_path("mooneye-test-suite/acceptance/oam_dma/sources-GS.gb"),


### PR DESCRIPTION
## Summary
- mirror DMG-mode OAM DMA addresses in the 0xFE00–0xFF9F range to the echoed WRAM so DMA reads the same data as hardware
- unignore the mooneye oam_dma__sources_GS_gb acceptance test and refresh TEST_STATUS.md

## Testing
- cargo fmt --all
- cargo test oam_dma__sources_GS_gb
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d2efb551208325b96af0b92b7ed24b