### PR TITLE
mmu: allow IE upper bits and fix serial open bus

### DIFF
--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -33,10 +33,10 @@ Combined exit code: 101
 
 | Category | Passed | Failed | Ignored | Measured | Total | Pass % |
 | --- | --- | --- | --- | --- | --- | --- |
-| ROM Test Suites | 117 | 68 | 0 | 0 | 185 | 63.2% |
+| ROM Test Suites | 118 | 67 | 0 | 0 | 185 | 63.8% |
 | Integration Tests | 156 | 18 | 0 | 0 | 174 | 89.7% |
 | Unit Tests | 5 | 0 | 0 | 0 | 5 | 100.0% |
-| **Overall** | 278 | 86 | 0 | 0 | 364 | 76.4% |
+| **Overall** | 279 | 85 | 0 | 0 | 364 | 76.6% |
 
 ## Failing Tests
 
@@ -67,7 +67,6 @@ Combined exit code: 101
 - `dmg_sound_10_wave_trigger_while_on` _(Category: ROM Test Suites; Module: dmg_sound_roms)_
 - `dmg_sound_11_regs_after_power` _(Category: ROM Test Suites; Module: dmg_sound_roms)_
 - `dmg_sound_12_wave_write_while_on` _(Category: ROM Test Suites; Module: dmg_sound_roms)_
-- `bits__unused_hwio_GS_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_div2_S_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_div_S_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_div_dmg0_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
@@ -203,13 +202,14 @@ Combined exit code: 101
 | `mem_timing_read` | ✅ Pass |
 | `mem_timing_write` | ✅ Pass |
 
-#### mooneye_acceptance (59/75 passing, 78.7%)
+#### mooneye_acceptance (60/75 passing, 80.0%)
 
 | Test | Result |
 | --- | --- |
 | `add_sp_e_timing_gb` | ✅ Pass |
 | `bits__mem_oam_gb` | ✅ Pass |
 | `bits__reg_f_gb` | ✅ Pass |
+| `bits__unused_hwio_GS_gb` | ✅ Pass |
 | `boot_hwio_dmg0_gb` | ✅ Pass |
 | `boot_hwio_dmgABCmgb_gb` | ✅ Pass |
 | `boot_regs_dmg0_gb` | ✅ Pass |
@@ -266,7 +266,6 @@ Combined exit code: 101
 | `timer__tima_reload_gb` | ✅ Pass |
 | `timer__tima_write_reloading_gb` | ✅ Pass |
 | `timer__tma_write_reloading_gb` | ✅ Pass |
-| `bits__unused_hwio_GS_gb` | ❌ Fail |
 | `boot_div2_S_gb` | ❌ Fail |
 | `boot_div_S_gb` | ❌ Fail |
 | `boot_div_dmg0_gb` | ❌ Fail |

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -433,7 +433,7 @@ impl Cpu {
     }
 
     fn handle_interrupts(&mut self, mmu: &mut crate::mmu::Mmu) {
-        let pending = mmu.if_reg & mmu.ie_reg;
+        let pending = (mmu.if_reg & mmu.ie_reg) & 0x1F;
         if pending == 0 {
             return;
         }
@@ -982,7 +982,7 @@ impl Cpu {
                 }
             }
             0x76 => {
-                let pending = mmu.if_reg & mmu.ie_reg;
+                let pending = (mmu.if_reg & mmu.ie_reg) & 0x1F;
                 if self.ime || pending == 0 {
                     self.enter_halt(self.pc, 0);
                 } else if self.ime_enable_delay > 0 {

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -396,7 +396,7 @@ impl Mmu {
                 }
             }
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize] = val,
-            0xFFFF => self.ie_reg = (val & 0x1F) | (self.ie_reg & 0xE0),
+            0xFFFF => self.ie_reg = val,
             _ => {}
         }
     }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -94,7 +94,13 @@ impl Serial {
     pub fn read(&self, addr: u16) -> u8 {
         match addr {
             0xFF01 => self.sb,
-            0xFF02 => self.sc,
+            0xFF02 => {
+                if self.cgb_mode {
+                    self.sc
+                } else {
+                    self.sc | 0x7E
+                }
+            }
             _ => 0xFF,
         }
     }

--- a/tests/mooneye_acceptance.rs
+++ b/tests/mooneye_acceptance.rs
@@ -62,7 +62,6 @@ fn bits__reg_f_gb() {
 }
 
 #[test]
-#[ignore]
 fn bits__unused_hwio_GS_gb() {
     let passed = run_mooneye_acceptance(
         common::rom_path("mooneye-test-suite/acceptance/bits/unused_hwio-GS.gb"),


### PR DESCRIPTION
## Summary
- ensure the DMG serial control register reports unused bits as open bus ones while keeping CGB behaviour unchanged
- let the interrupt enable register retain its upper bits and mask them out when selecting pending interrupts to avoid false triggers
- re-enable the mooneye unused HWIO acceptance test and refresh TEST_STATUS.md

## Testing
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d322d616888325b531cffa20c8dc0f