### PR TITLE
fix: align DMG boot DIV initialization with revision

### DIFF
--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -33,10 +33,10 @@ Combined exit code: 101
 
 | Category | Passed | Failed | Ignored | Measured | Total | Pass % |
 | --- | --- | --- | --- | --- | --- | --- |
-| ROM Test Suites | 118 | 67 | 0 | 0 | 185 | 63.8% |
+| ROM Test Suites | 120 | 65 | 0 | 0 | 185 | 64.9% |
 | Integration Tests | 156 | 18 | 0 | 0 | 174 | 89.7% |
 | Unit Tests | 5 | 0 | 0 | 0 | 5 | 100.0% |
-| **Overall** | 279 | 85 | 0 | 0 | 364 | 76.6% |
+| **Overall** | 281 | 83 | 0 | 0 | 364 | 77.2% |
 
 ## Failing Tests
 
@@ -69,8 +69,6 @@ Combined exit code: 101
 - `dmg_sound_12_wave_write_while_on` _(Category: ROM Test Suites; Module: dmg_sound_roms)_
 - `boot_div2_S_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_div_S_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
-- `boot_div_dmg0_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
-- `boot_div_dmgABCmgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_hwio_S_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_mgb_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
 - `boot_regs_sgb2_gb` _(Category: ROM Test Suites; Module: mooneye_acceptance)_
@@ -202,7 +200,7 @@ Combined exit code: 101
 | `mem_timing_read` | ✅ Pass |
 | `mem_timing_write` | ✅ Pass |
 
-#### mooneye_acceptance (60/75 passing, 80.0%)
+#### mooneye_acceptance (62/75 passing, 82.7%)
 
 | Test | Result |
 | --- | --- |
@@ -210,6 +208,8 @@ Combined exit code: 101
 | `bits__mem_oam_gb` | ✅ Pass |
 | `bits__reg_f_gb` | ✅ Pass |
 | `bits__unused_hwio_GS_gb` | ✅ Pass |
+| `boot_div_dmg0_gb` | ✅ Pass |
+| `boot_div_dmgABCmgb_gb` | ✅ Pass |
 | `boot_hwio_dmg0_gb` | ✅ Pass |
 | `boot_hwio_dmgABCmgb_gb` | ✅ Pass |
 | `boot_regs_dmg0_gb` | ✅ Pass |
@@ -268,8 +268,6 @@ Combined exit code: 101
 | `timer__tma_write_reloading_gb` | ✅ Pass |
 | `boot_div2_S_gb` | ❌ Fail |
 | `boot_div_S_gb` | ❌ Fail |
-| `boot_div_dmg0_gb` | ❌ Fail |
-| `boot_div_dmgABCmgb_gb` | ❌ Fail |
 | `boot_hwio_S_gb` | ❌ Fail |
 | `boot_regs_mgb_gb` | ❌ Fail |
 | `boot_regs_sgb2_gb` | ❌ Fail |

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -77,9 +77,12 @@ impl Mmu {
         cgb_revision: CgbRevision,
     ) -> Self {
         let mut timer = Timer::new();
+        // Power-on DIV phase differs between DMG revisions. These values match
+        // the phases measured by mooneye's boot_div acceptance tests so the
+        // first post-boot instruction sequence observes the expected timing.
         timer.div = match dmg_revision {
-            DmgRevision::Rev0 => 0x1800,
-            DmgRevision::RevA | DmgRevision::RevB | DmgRevision::RevC => 0xAC00,
+            DmgRevision::Rev0 => 0x1830,
+            DmgRevision::RevA | DmgRevision::RevB | DmgRevision::RevC => 0xABCC,
         };
 
         let mut ppu = Ppu::new_with_mode(cgb);

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -192,7 +192,7 @@ impl Serial {
         }
 
         match self.dmg_revision {
-            DmgRevision::RevA | DmgRevision::RevB | DmgRevision::RevC => 0x34,
+            DmgRevision::RevA | DmgRevision::RevB | DmgRevision::RevC => 0,
             DmgRevision::Rev0 => 0,
         }
     }

--- a/tests/mooneye_acceptance.rs
+++ b/tests/mooneye_acceptance.rs
@@ -81,21 +81,21 @@ fn boot_div_S_gb() {
 }
 
 #[test]
-#[ignore]
 fn boot_div_dmg0_gb() {
-    let passed = run_mooneye_acceptance(
+    let passed = run_mooneye_acceptance_with_dmg_revision(
         common::rom_path("mooneye-test-suite/acceptance/boot_div-dmg0.gb"),
         20_000_000,
+        DmgRevision::Rev0,
     );
     assert!(passed, "test failed");
 }
 
 #[test]
-#[ignore]
 fn boot_div_dmgABCmgb_gb() {
-    let passed = run_mooneye_acceptance(
+    let passed = run_mooneye_acceptance_with_dmg_revision(
         common::rom_path("mooneye-test-suite/acceptance/boot_div-dmgABCmgb.gb"),
         20_000_000,
+        DmgRevision::RevC,
     );
     assert!(passed, "test failed");
 }


### PR DESCRIPTION
## Summary
- set the DMG boot DIV phase to the hardware-accurate values for Rev0 and RevA/B/C and drop the legacy serial phase offset
- run the mooneye boot_div acceptance ROMs against the correct DMG revisions and stop ignoring them
- refresh TEST_STATUS.md to reflect the two newly passing acceptance tests

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py


------
https://chatgpt.com/codex/tasks/task_e_68d3294bb64c8325a2f4e9fc83127f87