### PR TITLE
cpu: hold apu state without per-cycle locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,7 +2774,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3163,7 +3172,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3502,6 +3511,7 @@ dependencies = [
  "bytemuck",
  "clap",
  "cpal",
+ "crossbeam-queue",
  "env_logger",
  "image",
  "imgui",
@@ -3888,7 +3898,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = "0.11"
 bytemuck = "1.23"
 rfd = { version = "0.15", default-features = false, features = ["gtk3"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
+crossbeam-queue = "0.3"
 
 [patch.crates-io]
 imgui-wgpu = { path = "vendor/imgui-wgpu-0.24.0" }

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -1,4 +1,8 @@
-use std::collections::VecDeque;
+use crossbeam_queue::ArrayQueue;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
+};
 
 use crate::hardware::CgbRevision;
 
@@ -16,9 +20,13 @@ const CPU_CLOCK_HZ: u32 = 4_194_304;
 // 512 Hz frame sequencer tick (not doubled in CGB mode)
 const FRAME_SEQUENCER_PERIOD: u32 = 8192;
 const VOLUME_FACTOR: i16 = 64;
+pub const DEFAULT_SAMPLE_RATE: u32 = 44_100;
 pub const AUDIO_LATENCY_MS: u32 = 40;
 // Audio sample pipeline delay is computed dynamically when a channel is
 // triggered.  See `trigger_square` for details.
+
+const AUDIO_FIFO_CAPACITY: usize =
+    ((DEFAULT_SAMPLE_RATE as usize * AUDIO_LATENCY_MS as usize) / 1000) * 2;
 
 const POWER_ON_REGS: [u8; 0x30] = [
     0x80, 0xBF, 0xF3, 0xFF, 0xBF, 0xFF, 0x3F, 0x00, 0xFF, 0xBF, 0x7F, 0xFF, 0x9F, 0xFF, 0xBF, 0xFF,
@@ -38,6 +46,53 @@ const DUTY_TABLE: [[u8; 8]; 4] = [
     [1, 0, 0, 0, 0, 1, 1, 1], // 50%   -> 10000111
     [0, 1, 1, 1, 1, 1, 1, 0], // 75%   -> 01111110
 ];
+
+#[derive(Clone)]
+pub struct ApuAudioBus {
+    queue: Arc<ArrayQueue<i16>>,
+    sample_rate: Arc<AtomicU32>,
+}
+
+impl ApuAudioBus {
+    pub fn new() -> Self {
+        Self::with_sample_rate(DEFAULT_SAMPLE_RATE)
+    }
+
+    pub fn with_sample_rate(initial_rate: u32) -> Self {
+        Self {
+            queue: Arc::new(ArrayQueue::new(AUDIO_FIFO_CAPACITY)),
+            sample_rate: Arc::new(AtomicU32::new(initial_rate)),
+        }
+    }
+
+    pub fn push(&self, sample: i16) {
+        while self.queue.push(sample).is_err() {
+            let _ = self.queue.pop();
+        }
+    }
+
+    pub fn pop(&self) -> Option<i16> {
+        self.queue.pop()
+    }
+
+    pub fn set_sample_rate(&self, rate: u32) {
+        self.sample_rate.store(rate, Ordering::Release);
+    }
+
+    pub fn desired_sample_rate(&self) -> u32 {
+        self.sample_rate.load(Ordering::Acquire)
+    }
+
+    pub fn clear(&self) {
+        while self.queue.pop().is_some() {}
+    }
+}
+
+impl Default for ApuAudioBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[derive(Default, Clone, Copy)]
 struct EnvelopeClock {
@@ -564,7 +619,7 @@ pub struct Apu {
     sequencer: FrameSequencer,
     sample_timer: u32,
     sample_rate: u32,
-    samples: VecDeque<i16>,
+    audio_bus: ApuAudioBus,
     pcm_samples: [u8; 4],
     pcm_active: [bool; 4],
     pcm_mask: [u8; 2],
@@ -606,9 +661,6 @@ pub struct Apu {
 }
 
 impl Apu {
-    // Keep <= 40 ms of stereo samples in the queue
-    const MAX_SAMPLES: usize = ((44100 * AUDIO_LATENCY_MS as usize) / 1000) * 2;
-
     fn calc_hp_coef(rate: u32) -> f32 {
         0.999_958_f32.powf(4_194_304.0 / rate as f32)
     }
@@ -621,11 +673,19 @@ impl Apu {
         if self.speed_factor != 1.0 {
             return;
         }
-        if self.samples.len() >= Self::MAX_SAMPLES {
-            let excess = self.samples.len() + 1 - Self::MAX_SAMPLES;
-            self.samples.drain(..excess);
+        self.audio_bus.push(s);
+    }
+
+    pub fn audio_bus(&self) -> ApuAudioBus {
+        self.audio_bus.clone()
+    }
+
+    fn sync_sample_rate_from_bus(&mut self) {
+        let desired = self.audio_bus.desired_sample_rate();
+        if desired != 0 && desired != self.sample_rate {
+            self.sample_rate = desired;
+            self.hp_coef = Apu::calc_hp_coef(desired);
         }
-        self.samples.push_back(s);
     }
 
     fn read_mask(addr: u16) -> u8 {
@@ -665,7 +725,7 @@ impl Apu {
         self.regs.fill(0);
         self.nr50 = 0;
         self.nr51 = 0;
-        self.samples.clear();
+        self.audio_bus.clear();
         self.pcm_samples = [0; 4];
         self.pcm_active = [false; 4];
         self.pcm_mask = [0xFF; 2];
@@ -771,7 +831,8 @@ impl Apu {
             Apu::nrx2_glitch_step(vol, new_val, old_val, lock)
         }
     }
-    fn new_internal() -> Self {
+    fn new_internal(audio_bus: ApuAudioBus) -> Self {
+        let sample_rate = audio_bus.desired_sample_rate();
         let mut apu = Self {
             ch1: SquareChannel::new(true),
             ch2: SquareChannel::new(false),
@@ -785,13 +846,13 @@ impl Apu {
             nr52: 0xF1,
             sequencer: FrameSequencer::new(),
             sample_timer: 0,
-            sample_rate: 44_100,
-            samples: VecDeque::with_capacity(Self::MAX_SAMPLES),
+            sample_rate,
+            audio_bus,
             pcm_samples: [0; 4],
             pcm_active: [false; 4],
             pcm_mask: [0xFF; 2],
             speed_factor: 1.0,
-            hp_coef: Apu::calc_hp_coef(44_100),
+            hp_coef: Apu::calc_hp_coef(sample_rate),
             hp_prev_input_left: 0.0,
             hp_prev_output_left: 0.0,
             hp_prev_input_right: 0.0,
@@ -849,7 +910,16 @@ impl Apu {
     }
 
     pub fn new_with_config(cgb: bool, revision: CgbRevision) -> Self {
-        let mut apu = Self::new_internal();
+        let bus = ApuAudioBus::new();
+        let mut apu = Self::new_internal(bus);
+        apu.cgb_mode = cgb;
+        apu.cgb_revision = revision;
+        apu.hp_coef = Apu::calc_hp_coef(apu.sample_rate);
+        apu
+    }
+
+    pub fn with_audio_bus(cgb: bool, revision: CgbRevision, audio_bus: ApuAudioBus) -> Self {
+        let mut apu = Self::new_internal(audio_bus);
         apu.cgb_mode = cgb;
         apu.cgb_revision = revision;
         apu.hp_coef = Apu::calc_hp_coef(apu.sample_rate);
@@ -1384,6 +1454,7 @@ impl Apu {
         // Store the current CPU speed so trigger_square can select the
         // correct initial delay when a channel is triggered.
         self.double_speed = double_speed;
+        self.sync_sample_rate_from_bus();
         // Double-speed mode halves the CPU cycles per M-cycle, but we still emit
         // one 1 MHz stage tick every two CPU cycles so the staging pipeline aligns to the 1 MHz domain.
         let ticks = if double_speed { 2 } else { 4 };
@@ -1723,10 +1794,11 @@ impl Apu {
     pub fn set_sample_rate(&mut self, rate: u32) {
         self.sample_rate = rate;
         self.hp_coef = Apu::calc_hp_coef(rate);
+        self.audio_bus.set_sample_rate(rate);
     }
 
     pub fn pop_sample(&mut self) -> Option<i16> {
-        self.samples.pop_front()
+        self.audio_bus.pop()
     }
 
     pub fn sequencer_step(&self) -> u8 {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,11 +1,10 @@
-use crate::apu::Apu;
+use crate::apu::ApuAudioBus;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use std::sync::{Arc, Mutex};
 
 /// Start audio playback using `cpal` and stream samples produced by the APU.
 ///
 /// Returns the active [`cpal::Stream`] if successful.
-pub fn start_stream(apu: Arc<Mutex<Apu>>) -> Option<cpal::Stream> {
+pub fn start_stream(bus: ApuAudioBus) -> Option<cpal::Stream> {
     let host = cpal::default_host();
     let device = host.default_output_device()?;
     let supported = match device.default_output_config() {
@@ -17,68 +16,75 @@ pub fn start_stream(apu: Arc<Mutex<Apu>>) -> Option<cpal::Stream> {
     };
     let sample_format = supported.sample_format();
     let config: cpal::StreamConfig = supported.into();
-    {
-        let mut a = apu.lock().unwrap();
-        a.set_sample_rate(config.sample_rate.0);
-    }
+    bus.set_sample_rate(config.sample_rate.0);
     let channels = config.channels as usize;
     let err_fn = |err| eprintln!("cpal stream error: {err}");
 
+    let bus_i16 = bus.clone();
+    let bus_u16 = bus.clone();
+    let bus_f32 = bus;
+
     let stream = match sample_format {
-        cpal::SampleFormat::I16 => device
-            .build_output_stream(
-                &config,
-                move |data: &mut [i16], _| {
-                    let mut apu = apu.lock().unwrap();
-                    for frame in data.chunks_mut(channels) {
-                        let left = apu.pop_sample().unwrap_or(0);
-                        let right = apu.pop_sample().unwrap_or(0);
-                        frame[0] = left;
-                        if channels > 1 {
-                            frame[1] = right;
+        cpal::SampleFormat::I16 => {
+            let bus = bus_i16;
+            device
+                .build_output_stream(
+                    &config,
+                    move |data: &mut [i16], _| {
+                        for frame in data.chunks_mut(channels) {
+                            let left = bus.pop().unwrap_or(0);
+                            let right = bus.pop().unwrap_or(0);
+                            frame[0] = left;
+                            if channels > 1 {
+                                frame[1] = right;
+                            }
                         }
-                    }
-                },
-                err_fn,
-                None,
-            )
-            .unwrap(),
-        cpal::SampleFormat::U16 => device
-            .build_output_stream(
-                &config,
-                move |data: &mut [u16], _| {
-                    let mut apu = apu.lock().unwrap();
-                    for frame in data.chunks_mut(channels) {
-                        let left = apu.pop_sample().unwrap_or(0);
-                        let right = apu.pop_sample().unwrap_or(0);
-                        frame[0] = (left as i32 + 32768) as u16;
-                        if channels > 1 {
-                            frame[1] = (right as i32 + 32768) as u16;
+                    },
+                    err_fn,
+                    None,
+                )
+                .unwrap()
+        }
+        cpal::SampleFormat::U16 => {
+            let bus = bus_u16;
+            device
+                .build_output_stream(
+                    &config,
+                    move |data: &mut [u16], _| {
+                        for frame in data.chunks_mut(channels) {
+                            let left = bus.pop().unwrap_or(0);
+                            let right = bus.pop().unwrap_or(0);
+                            frame[0] = (left as i32 + 32768) as u16;
+                            if channels > 1 {
+                                frame[1] = (right as i32 + 32768) as u16;
+                            }
                         }
-                    }
-                },
-                err_fn,
-                None,
-            )
-            .unwrap(),
-        cpal::SampleFormat::F32 => device
-            .build_output_stream(
-                &config,
-                move |data: &mut [f32], _| {
-                    let mut apu = apu.lock().unwrap();
-                    for frame in data.chunks_mut(channels) {
-                        let left = apu.pop_sample().unwrap_or(0) as f32 / 32768.0;
-                        let right = apu.pop_sample().unwrap_or(0) as f32 / 32768.0;
-                        frame[0] = left;
-                        if channels > 1 {
-                            frame[1] = right;
+                    },
+                    err_fn,
+                    None,
+                )
+                .unwrap()
+        }
+        cpal::SampleFormat::F32 => {
+            let bus = bus_f32;
+            device
+                .build_output_stream(
+                    &config,
+                    move |data: &mut [f32], _| {
+                        for frame in data.chunks_mut(channels) {
+                            let left = bus.pop().unwrap_or(0) as f32 / 32768.0;
+                            let right = bus.pop().unwrap_or(0) as f32 / 32768.0;
+                            frame[0] = left;
+                            if channels > 1 {
+                                frame[1] = right;
+                            }
                         }
-                    }
-                },
-                err_fn,
-                None,
-            )
-            .unwrap(),
+                    },
+                    err_fn,
+                    None,
+                )
+                .unwrap()
+        }
         _ => panic!("Unsupported sample format"),
     };
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -221,14 +221,11 @@ impl Cpu {
         let prev_div = mmu.timer.div;
         mmu.timer.step(hw_cycles, &mut mmu.if_reg);
         let curr_div = mmu.timer.div;
-        {
-            let mut apu = mmu.apu.lock().unwrap();
-            // Advance 2 MHz domain first so duty edges and suppression changes
-            // are visible to the subsequent 1 MHz staging/PCM update in the
-            // same CPU step (aligns with the APU's internal ordering for audio updates).
-            apu.step(hw_cycles);
-            apu.tick(prev_div, curr_div, self.double_speed);
-        }
+        // Advance 2 MHz domain first so duty edges and suppression changes
+        // are visible to the subsequent 1 MHz staging/PCM update in the
+        // same CPU step (aligns with the APU's internal ordering for audio updates).
+        mmu.apu.step(hw_cycles);
+        mmu.apu.tick(prev_div, curr_div, self.double_speed);
         mmu.serial
             .step(prev_div, curr_div, self.double_speed, &mut mmu.if_reg);
         if mmu.ppu.step(hw_cycles, &mut mmu.if_reg) {

--- a/src/gameboy.rs
+++ b/src/gameboy.rs
@@ -44,8 +44,9 @@ impl GameBoy {
     pub fn reset(&mut self) {
         let cart = self.mmu.cart.take();
         let boot = self.mmu.boot_rom.take();
+        let audio_bus = self.mmu.audio_bus.clone();
         self.cpu = Cpu::new_with_mode_and_revision(self.cgb, self.dmg_revision);
-        self.mmu = Mmu::new_with_revisions(self.cgb, self.dmg_revision, self.cgb_revision);
+        self.mmu = Mmu::with_audio_bus(self.cgb, self.dmg_revision, self.cgb_revision, audio_bus);
         if let Some(c) = cart {
             self.mmu.load_cart(c);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use log::info;
 use pixels::{Pixels, SurfaceTexture};
 use rfd::FileDialog;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 use winit::dpi::PhysicalPosition;
 use winit::event::{ElementState, Event, MouseButton, WindowEvent};
@@ -166,9 +165,7 @@ fn spawn_vram_window(
 fn emulate_until(gb: &mut gameboy::GameBoy, speed: Speed, event_loop: &ActiveEventLoop) {
     let target = unsafe { NEXT_FRAME.get_or_insert_with(|| Instant::now() + FRAME_TIME) };
 
-    if let Ok(mut apu) = gb.mmu.apu.lock() {
-        apu.set_speed(speed.factor);
-    }
+    gb.mmu.apu.set_speed(speed.factor);
 
     while !gb.mmu.ppu.frame_ready() {
         gb.cpu.step(&mut gb.mmu);
@@ -374,7 +371,7 @@ fn main() {
     let _stream = if args.headless {
         None
     } else {
-        audio::start_stream(Arc::clone(&gb.mmu.apu))
+        audio::start_stream(gb.mmu.audio_bus.clone())
     };
 
     let mut frame = vec![0u32; 160 * 144];
@@ -496,9 +493,7 @@ fn main() {
                                     let mask = if code == KeyCode::Space {
                                         speed.fast = pressed;
                                         speed.factor = if speed.fast { FF_MULT } else { 1.0 };
-                                        if let Ok(mut apu) = gb.mmu.apu.lock() {
-                                            apu.set_speed(speed.factor);
-                                        }
+                                        gb.mmu.apu.set_speed(speed.factor);
                                         None
                                     } else {
                                         match code {

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -1,5 +1,5 @@
 use crate::{
-    apu::Apu,
+    apu::{Apu, ApuAudioBus},
     cartridge::Cartridge,
     hardware::{CgbRevision, DmgRevision},
     input::Input,
@@ -7,7 +7,6 @@ use crate::{
     serial::Serial,
     timer::Timer,
 };
-use std::sync::{Arc, Mutex};
 
 const WRAM_BANK_SIZE: usize = 0x1000;
 
@@ -45,7 +44,8 @@ pub struct Mmu {
     pub ie_reg: u8,
     pub serial: Serial,
     pub ppu: Ppu,
-    pub apu: Arc<Mutex<Apu>>,
+    pub apu: Apu,
+    pub audio_bus: ApuAudioBus,
     pub timer: Timer,
     pub input: Input,
     hdma: HdmaState,
@@ -76,6 +76,16 @@ impl Mmu {
         dmg_revision: DmgRevision,
         cgb_revision: CgbRevision,
     ) -> Self {
+        let audio_bus = ApuAudioBus::new();
+        Self::with_audio_bus(cgb, dmg_revision, cgb_revision, audio_bus)
+    }
+
+    pub fn with_audio_bus(
+        cgb: bool,
+        dmg_revision: DmgRevision,
+        cgb_revision: CgbRevision,
+        audio_bus: ApuAudioBus,
+    ) -> Self {
         let mut timer = Timer::new();
         // Power-on DIV phase differs between DMG revisions. These values match
         // the phases measured by mooneye's boot_div acceptance tests so the
@@ -88,6 +98,8 @@ impl Mmu {
         let mut ppu = Ppu::new_with_mode(cgb);
         ppu.apply_boot_state(if cgb { None } else { Some(dmg_revision) });
 
+        let apu = Apu::with_audio_bus(cgb, cgb_revision, audio_bus.clone());
+
         Self {
             wram: [[0; WRAM_BANK_SIZE]; 8],
             wram_bank: 1,
@@ -99,7 +111,8 @@ impl Mmu {
             ie_reg: 0,
             serial: Serial::new(cgb, dmg_revision),
             ppu,
-            apu: Arc::new(Mutex::new(Apu::new_with_config(cgb, cgb_revision))),
+            apu,
+            audio_bus,
             timer,
             input: Input::new(),
             hdma: HdmaState {
@@ -189,7 +202,7 @@ impl Mmu {
             0xFF01 | 0xFF02 => self.serial.read(addr),
             0xFF04..=0xFF07 => self.timer.read(addr),
             0xFF0F => self.if_reg,
-            0xFF10..=0xFF3F => self.apu.lock().unwrap().read_reg(addr),
+            0xFF10..=0xFF3F => self.apu.read_reg(addr),
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B | 0xFF68..=0xFF6B => self.ppu.read_reg(addr),
             0xFF46 => self.ppu.dma,
             0xFF51 => {
@@ -264,7 +277,7 @@ impl Mmu {
             }
             0xFF76 | 0xFF77 => {
                 if self.cgb_mode {
-                    self.apu.lock().unwrap().read_pcm(addr)
+                    self.apu.read_pcm(addr)
                 } else {
                     0xFF
                 }
@@ -326,7 +339,7 @@ impl Mmu {
             0xFF01 | 0xFF02 => self.serial.write(addr, val),
             0xFF04..=0xFF07 => self.timer.write(addr, val, &mut self.if_reg),
             0xFF0F => self.if_reg = (val & 0x1F) | (self.if_reg & 0xE0),
-            0xFF10..=0xFF3F => self.apu.lock().unwrap().write_reg(addr, val),
+            0xFF10..=0xFF3F => self.apu.write_reg(addr, val),
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B | 0xFF68..=0xFF6B => self.ppu.write_reg(addr, val),
             0xFF51 => {
                 if self.cgb_mode && !self.hdma.active {
@@ -512,12 +525,9 @@ impl Mmu {
         let prev_div = self.timer.div;
         self.timer.step(hw_cycles, &mut self.if_reg);
         let curr_div = self.timer.div;
-        {
-            let mut apu = self.apu.lock().unwrap();
-            // Advance 2 MHz domain before 1 MHz staging to match APU internal ordering
-            apu.step(hw_cycles);
-            apu.tick(prev_div, curr_div, self.key1 & 0x80 != 0);
-        }
+        // Advance 2 MHz domain before 1 MHz staging to match APU internal ordering
+        self.apu.step(hw_cycles);
+        self.apu.tick(prev_div, curr_div, self.key1 & 0x80 != 0);
         let _ = self.ppu.step(hw_cycles, &mut self.if_reg);
     }
 }

--- a/tests/apu.rs
+++ b/tests/apu.rs
@@ -299,10 +299,10 @@ fn pcm_mmu_mapping() {
     mmu.write_byte(0xFF17, 0xF0);
     mmu.write_byte(0xFF19, 0x80);
     {
-        let mut apu = mmu.apu.lock().unwrap();
+        let apu = &mut mmu.apu;
         let mut div = 0u16;
         for _ in 0..(8300 / 4) {
-            tick_machine(&mut apu, &mut div, 4);
+            tick_machine(apu, &mut div, 4);
         }
     }
     assert_eq!(mmu.read_byte(0xFF76), 0xF0);


### PR DESCRIPTION
## Summary
- introduce `ApuAudioBus` to share PCM samples and sample rate requests without locking
- give the CPU exclusive ownership of the APU while the audio callback consumes samples through the new bus
- update MMU, Game Boy reset logic, and the audio backend to use the new ownership model

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py


------
https://chatgpt.com/codex/tasks/task_e_68d33d881bf88325a37fc5c75d3fecd0