### PR TITLE
apu: resample audio using accurate cycle ratio

### DIFF
--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -34,9 +34,9 @@ Combined exit code: 101
 | Category | Passed | Failed | Ignored | Measured | Total | Pass % |
 | --- | --- | --- | --- | --- | --- | --- |
 | ROM Test Suites | 123 | 62 | 0 | 0 | 185 | 66.5% |
-| Integration Tests | 156 | 18 | 0 | 0 | 174 | 89.7% |
+| Integration Tests | 157 | 18 | 0 | 0 | 175 | 89.7% |
 | Unit Tests | 5 | 0 | 0 | 0 | 5 | 100.0% |
-| **Overall** | 284 | 80 | 0 | 0 | 364 | 78.0% |
+| **Overall** | 285 | 80 | 0 | 0 | 365 | 78.1% |
 
 ## Failing Tests
 
@@ -363,7 +363,7 @@ Combined exit code: 101
 
 ### Integration Tests
 
-#### apu (91/109 passing, 83.5%)
+#### apu (92/110 passing, 83.6%)
 
 | Test | Result |
 | --- | --- |
@@ -373,6 +373,7 @@ Combined exit code: 101
 | `double_speed_preserves_lf_div_phase` | ✅ Pass |
 | `duty_step_reset_when_apu_powered_off` | ✅ Pass |
 | `envelope_zero_does_not_disable_channel` | ✅ Pass |
+| `honours_requested_sample_rate` | ✅ Pass |
 | `nr11_length_counter_expires` | ✅ Pass |
 | `nr11_write_sets_duty_and_length` | ✅ Pass |
 | `nr12_bit3_enables_dac` | ✅ Pass |

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -1585,7 +1585,6 @@ impl Apu {
     }
 
     pub fn step(&mut self, cycles: u16) {
-        let cps = CPU_CLOCK_HZ / self.sample_rate;
         // Advance square channels at 2 MHz: 1 tick per 2 CPU cycles (accumulated)
         self.mhz2_residual += cycles as i32;
         let ticks_2mhz = self.mhz2_residual / 2;
@@ -1607,9 +1606,9 @@ impl Apu {
             self.cpu_cycles = self.cpu_cycles.wrapping_add(1);
             self.ch3.step(1, &self.wave_ram);
             self.ch4.step(1);
-            self.sample_timer += 1;
-            if self.sample_timer >= cps {
-                self.sample_timer -= cps;
+            self.sample_timer = self.sample_timer.saturating_add(self.sample_rate);
+            while self.sample_timer >= CPU_CLOCK_HZ {
+                self.sample_timer -= CPU_CLOCK_HZ;
                 let (left, right) = self.mix_output();
                 self.push_sample(left);
                 self.push_sample(right);

--- a/tests/apu.rs
+++ b/tests/apu.rs
@@ -10,6 +10,36 @@ fn tick_machine(apu: &mut Apu, div: &mut u16, cycles: u16) {
 }
 
 #[test]
+fn honours_requested_sample_rate() {
+    const CPU_CLOCK_HZ: u64 = 4_194_304;
+    const SAMPLE_RATE: u32 = 9_600;
+    const TEST_CYCLES: u32 = (CPU_CLOCK_HZ / 10) as u32;
+    const STEP: u16 = 32;
+
+    let mut apu = Apu::new();
+    apu.set_sample_rate(SAMPLE_RATE);
+
+    let mut remaining = TEST_CYCLES;
+    while remaining >= STEP as u32 {
+        apu.step(STEP);
+        remaining -= STEP as u32;
+    }
+    if remaining > 0 {
+        apu.step(remaining as u16);
+    }
+
+    let mut produced = 0usize;
+    while apu.pop_sample().is_some() {
+        produced += 1;
+    }
+
+    assert_eq!(produced % 2, 0, "APU output should produce stereo pairs");
+
+    let expected_frames = ((TEST_CYCLES as u64) * SAMPLE_RATE as u64 / CPU_CLOCK_HZ) as usize;
+    assert_eq!(produced, expected_frames * 2);
+}
+
+#[test]
 #[ignore]
 fn frame_sequencer_tick() {
     let mut apu = Apu::new();


### PR DESCRIPTION
## Summary
- fix the APU sample scheduler to accumulate host sample rate precisely so the audio stream does not drift
- add a regression test that ensures the number of produced samples matches the configured rate
- refresh TEST_STATUS.md after running the full suite

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d36039de988325bc1ee9d33c9e2999