### PR TITLE
Reduce dependency footprint by switching to png decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,15 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,12 +336,6 @@ name = "bytemuck"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -776,29 +761,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -1454,19 +1416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "moxcms",
- "num-traits",
- "png",
-]
-
-[[package]]
 name = "imgui"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,30 +1528,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "jni"
@@ -1842,16 +1767,6 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "moxcms"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
-dependencies = [
- "num-traits",
- "pxfm",
 ]
 
 [[package]]
@@ -2466,11 +2381,11 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2496,21 +2411,6 @@ name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -2556,15 +2456,6 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
-
-[[package]]
-name = "pxfm"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f9b339b02259ada5c0f4a389b7fb472f933aa17ce176fd2ad98f28bb401fde"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "quick-xml"
@@ -2625,35 +2516,6 @@ checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
 dependencies = [
  "bitflags 2.9.1",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "renderdoc-sys"
@@ -2765,7 +2627,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3163,7 +3025,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3499,8 +3361,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vibe-emu-core"
 version = "0.1.0"
 dependencies = [
- "image",
  "once_cell",
+ "png",
  "reqwest",
  "tempfile",
  "zip",
@@ -3510,16 +3372,13 @@ dependencies = [
 name = "vibe-emu-ui"
 version = "0.1.0"
 dependencies = [
- "bytemuck",
  "clap",
  "cpal",
- "env_logger",
- "image",
  "imgui",
  "imgui-wgpu",
  "imgui-winit-support",
- "log",
  "pixels",
+ "png",
  "rfd",
  "vibe-emu-core",
  "wgpu",
@@ -3896,7 +3755,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/vibe-emu-core/Cargo.toml
+++ b/crates/vibe-emu-core/Cargo.toml
@@ -12,4 +12,4 @@ once_cell = "1"
 tempfile = "3"
 reqwest = { version = "0.12", features = ["blocking", "gzip"] }
 zip = "4.3"
-image = { version = "0.25", default-features = false, features = ["png"] }
+png = "0.17"

--- a/crates/vibe-emu-core/tests/cgb_acid2_rom.rs
+++ b/crates/vibe-emu-core/tests/cgb_acid2_rom.rs
@@ -1,5 +1,4 @@
 mod common;
-use image::ImageReader;
 use vibe_emu_core::{cartridge::Cartridge, gameboy::GameBoy};
 
 #[test]
@@ -17,17 +16,14 @@ fn cgb_acid2_rom() {
         }
     }
 
-    let expected = ImageReader::open(common::rom_path("cgb-acid2/cgb-acid2.png"))
-        .unwrap()
-        .decode()
-        .unwrap()
-        .to_rgb8();
-    assert_eq!(expected.width(), 160);
-    assert_eq!(expected.height(), 144);
+    let (width, height, expected) =
+        common::load_png_rgb(common::rom_path("cgb-acid2/cgb-acid2.png"));
+    assert_eq!(width, 160);
+    assert_eq!(height, 144);
 
     let frame = gb.mmu.ppu.framebuffer();
-    for (idx, pixel) in expected.pixels().enumerate() {
-        let expected_color = ((pixel[0] as u32) << 16) | ((pixel[1] as u32) << 8) | pixel[2] as u32;
+    for (idx, [r, g, b]) in expected.iter().copied().enumerate() {
+        let expected_color = (r as u32) << 16 | (g as u32) << 8 | b as u32;
         assert_eq!(frame[idx], expected_color, "pixel mismatch at index {idx}");
     }
 }

--- a/crates/vibe-emu-core/tests/common/mod.rs
+++ b/crates/vibe-emu-core/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::OnceCell;
-use std::fs;
+use std::fs::{self, File};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 static INIT: OnceCell<()> = OnceCell::new();
@@ -45,4 +46,57 @@ pub fn workspace_root() -> PathBuf {
         .expect("crate directory should have a parent");
     // workspace root
     ancestors.next().unwrap_or(crates_dir).to_path_buf()
+}
+
+#[allow(dead_code)]
+pub fn load_png_rgb<P: AsRef<Path>>(path: P) -> (u32, u32, Vec<[u8; 3]>) {
+    let file = File::open(path.as_ref()).expect("failed to open png");
+    let reader = BufReader::new(file);
+    let mut decoder = png::Decoder::new(reader);
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut png_reader = decoder.read_info().expect("failed to read png info");
+    let mut buf = vec![0; png_reader.output_buffer_size()];
+    let info = png_reader
+        .next_frame(&mut buf)
+        .expect("failed to decode png frame");
+    let data = &buf[..info.buffer_size()];
+    let pixel_count = (info.width as usize) * (info.height as usize);
+    let mut pixels = Vec::with_capacity(pixel_count);
+    match png_reader.info().color_type {
+        png::ColorType::Rgb => {
+            for chunk in data.chunks_exact(3) {
+                pixels.push([chunk[0], chunk[1], chunk[2]]);
+            }
+        }
+        png::ColorType::Rgba => {
+            for chunk in data.chunks_exact(4) {
+                pixels.push([chunk[0], chunk[1], chunk[2]]);
+            }
+        }
+        png::ColorType::Grayscale => {
+            for &gray in data {
+                pixels.push([gray, gray, gray]);
+            }
+        }
+        png::ColorType::GrayscaleAlpha => {
+            for chunk in data.chunks_exact(2) {
+                let g = chunk[0];
+                pixels.push([g, g, g]);
+            }
+        }
+        png::ColorType::Indexed => {
+            if data.len() == pixel_count * 3 {
+                for chunk in data.chunks_exact(3) {
+                    pixels.push([chunk[0], chunk[1], chunk[2]]);
+                }
+            } else if data.len() == pixel_count * 4 {
+                for chunk in data.chunks_exact(4) {
+                    pixels.push([chunk[0], chunk[1], chunk[2]]);
+                }
+            } else {
+                panic!("unexpected palette expansion");
+            }
+        }
+    }
+    (info.width, info.height, pixels)
 }

--- a/crates/vibe-emu-core/tests/dmg_acid2_rom.rs
+++ b/crates/vibe-emu-core/tests/dmg_acid2_rom.rs
@@ -1,5 +1,4 @@
 mod common;
-use image::ImageReader;
 use vibe_emu_core::{cartridge::Cartridge, gameboy::GameBoy};
 
 const DMG_PALETTE: [u32; 4] = [0x009BBC0F, 0x008BAC0F, 0x00306230, 0x000F380F];
@@ -19,17 +18,14 @@ fn dmg_acid2_rom() {
         }
     }
 
-    let expected = ImageReader::open(common::rom_path("dmg-acid2/dmg-acid2-dmg.png"))
-        .unwrap()
-        .decode()
-        .unwrap()
-        .to_rgb8();
-    assert_eq!(expected.width(), 160);
-    assert_eq!(expected.height(), 144);
+    let (width, height, expected) =
+        common::load_png_rgb(common::rom_path("dmg-acid2/dmg-acid2-dmg.png"));
+    assert_eq!(width, 160);
+    assert_eq!(height, 144);
 
     let frame = gb.mmu.ppu.framebuffer();
-    for (idx, pixel) in expected.pixels().enumerate() {
-        let expected_color = match pixel.0 {
+    for (idx, pixel) in expected.iter().copied().enumerate() {
+        let expected_color = match pixel {
             [0x00, 0x00, 0x00] => DMG_PALETTE[3],
             [0x55, 0x55, 0x55] => DMG_PALETTE[2],
             [0xAA, 0xAA, 0xAA] => DMG_PALETTE[1],

--- a/crates/vibe-emu-core/tests/dmg_sound_roms.rs
+++ b/crates/vibe-emu-core/tests/dmg_sound_roms.rs
@@ -1,5 +1,4 @@
 mod common;
-use image::ImageReader;
 use std::path::Path;
 use vibe_emu_core::{cartridge::Cartridge, gameboy::GameBoy};
 
@@ -19,17 +18,13 @@ fn run_rom<P: AsRef<Path>, Q: AsRef<Path>>(rom_path: P, screenshot_path: Q) {
         }
     }
 
-    let expected = ImageReader::open(screenshot_path)
-        .unwrap()
-        .decode()
-        .unwrap()
-        .to_rgb8();
-    assert_eq!(expected.width(), 160);
-    assert_eq!(expected.height(), 144);
+    let (width, height, expected) = common::load_png_rgb(screenshot_path);
+    assert_eq!(width, 160);
+    assert_eq!(height, 144);
 
     let frame = gb.mmu.ppu.framebuffer();
-    for (idx, pixel) in expected.pixels().enumerate() {
-        let expected_color = match pixel.0 {
+    for (idx, pixel) in expected.iter().copied().enumerate() {
+        let expected_color = match pixel {
             [0xE0, 0xF8, 0xD0] => DMG_PALETTE[0],
             [0x08, 0x18, 0x20] => DMG_PALETTE[3],
             _ => panic!("unexpected color {:?}", pixel),

--- a/crates/vibe-emu-core/tests/halt_bug_rom.rs
+++ b/crates/vibe-emu-core/tests/halt_bug_rom.rs
@@ -1,5 +1,4 @@
 mod common;
-use image::ImageReader;
 use vibe_emu_core::{cartridge::Cartridge, gameboy::GameBoy};
 
 const DMG_PALETTE: [u32; 4] = [0x009BBC0F, 0x008BAC0F, 0x00306230, 0x000F380F];
@@ -19,17 +18,14 @@ fn halt_bug_rom() {
         }
     }
 
-    let expected = ImageReader::open(common::rom_path("blargg/halt_bug-dmg-cgb.png"))
-        .unwrap()
-        .decode()
-        .unwrap()
-        .to_rgb8();
-    assert_eq!(expected.width(), 160);
-    assert_eq!(expected.height(), 144);
+    let (width, height, expected) =
+        common::load_png_rgb(common::rom_path("blargg/halt_bug-dmg-cgb.png"));
+    assert_eq!(width, 160);
+    assert_eq!(height, 144);
 
     let frame = gb.mmu.ppu.framebuffer();
-    for (idx, pixel) in expected.pixels().enumerate() {
-        let expected_color = match pixel.0 {
+    for (idx, pixel) in expected.iter().copied().enumerate() {
+        let expected_color = match pixel {
             [0x00, 0x00, 0x00] => DMG_PALETTE[3],
             [0x55, 0x55, 0x55] => DMG_PALETTE[2],
             [0xAA, 0xAA, 0xAA] => DMG_PALETTE[1],

--- a/crates/vibe-emu-ui/Cargo.toml
+++ b/crates/vibe-emu-ui/Cargo.toml
@@ -13,8 +13,5 @@ imgui = { version = "0.12", features = ["docking", "tables-api"] }
 imgui-winit-support = "0.13"
 imgui-wgpu = "0.24"
 cpal = "0.16"
-log = "0.4"
-env_logger = "0.11"
-bytemuck = "1.23"
 rfd = { version = "0.15", default-features = false, features = ["gtk3"] }
-image = { version = "0.25", default-features = false, features = ["png"] }
+png = "0.17"


### PR DESCRIPTION
## Summary
- replace the image dev-dependency in vibe-emu-core with png and add a shared PNG loader for integration tests
- update the DMG/CGB screenshot-based tests to use the new loader instead of image::ImageReader
- drop the log/env_logger/bytemuck dependencies from vibe-emu-ui, decode the window icon with png, and write pixels without bytemuck

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
- cargo test --release
- python scripts/update_test_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d49ccd2d008325a05614d2a446e08e