### PR TITLE
tests: avoid copying cached PNG pixels

### DIFF
--- a/crates/vibe-emu-core/tests/cgb_acid2_rom.rs
+++ b/crates/vibe-emu-core/tests/cgb_acid2_rom.rs
@@ -22,7 +22,8 @@ fn cgb_acid2_rom() {
     assert_eq!(height, 144);
 
     let frame = gb.mmu.ppu.framebuffer();
-    for (idx, [r, g, b]) in expected.iter().copied().enumerate() {
+    for (idx, pixel) in expected.iter().enumerate() {
+        let &[r, g, b] = pixel;
         let expected_color = (r as u32) << 16 | (g as u32) << 8 | b as u32;
         assert_eq!(frame[idx], expected_color, "pixel mismatch at index {idx}");
     }

--- a/crates/vibe-emu-core/tests/dmg_acid2_rom.rs
+++ b/crates/vibe-emu-core/tests/dmg_acid2_rom.rs
@@ -24,7 +24,8 @@ fn dmg_acid2_rom() {
     assert_eq!(height, 144);
 
     let frame = gb.mmu.ppu.framebuffer();
-    for (idx, pixel) in expected.iter().copied().enumerate() {
+    for (idx, pixel) in expected.iter().enumerate() {
+        let pixel = *pixel;
         let expected_color = match pixel {
             [0x00, 0x00, 0x00] => DMG_PALETTE[3],
             [0x55, 0x55, 0x55] => DMG_PALETTE[2],

--- a/crates/vibe-emu-core/tests/dmg_sound_roms.rs
+++ b/crates/vibe-emu-core/tests/dmg_sound_roms.rs
@@ -23,7 +23,8 @@ fn run_rom<P: AsRef<Path>, Q: AsRef<Path>>(rom_path: P, screenshot_path: Q) {
     assert_eq!(height, 144);
 
     let frame = gb.mmu.ppu.framebuffer();
-    for (idx, pixel) in expected.iter().copied().enumerate() {
+    for (idx, pixel) in expected.iter().enumerate() {
+        let pixel = *pixel;
         let expected_color = match pixel {
             [0xE0, 0xF8, 0xD0] => DMG_PALETTE[0],
             [0x08, 0x18, 0x20] => DMG_PALETTE[3],

--- a/crates/vibe-emu-core/tests/gambatte.rs
+++ b/crates/vibe-emu-core/tests/gambatte.rs
@@ -309,7 +309,7 @@ fn verify_result(run: &GambatteRun, stem: &str, out_str: &str, mode: Mode) -> Re
 }
 
 fn verify_png(run: &GambatteRun, stem: &str, png_path: &Path, mode: Mode) -> Result<(), String> {
-    let (width, height, mut expected) = common::load_png_rgb(png_path);
+    let (width, height, expected) = common::load_png_rgb(png_path);
     if width as usize != GB_WIDTH {
         return Err(format!("unexpected PNG width for {stem}"));
     }
@@ -317,7 +317,7 @@ fn verify_png(run: &GambatteRun, stem: &str, png_path: &Path, mode: Mode) -> Res
         return Err(format!("unexpected PNG height for {stem}"));
     }
 
-    for (idx, pixel) in expected.iter_mut().enumerate() {
+    for (idx, pixel) in expected.iter().enumerate() {
         let expected_pixel = normalize_pixel(pixel, mode);
         let actual = normalize_color(run.frame[idx], mode);
         if actual != expected_pixel {
@@ -326,7 +326,6 @@ fn verify_png(run: &GambatteRun, stem: &str, png_path: &Path, mode: Mode) -> Res
                 mode, expected_pixel, actual
             ));
         }
-        *pixel = expected_pixel;
     }
     Ok(())
 }

--- a/crates/vibe-emu-core/tests/halt_bug_rom.rs
+++ b/crates/vibe-emu-core/tests/halt_bug_rom.rs
@@ -24,7 +24,8 @@ fn halt_bug_rom() {
     assert_eq!(height, 144);
 
     let frame = gb.mmu.ppu.framebuffer();
-    for (idx, pixel) in expected.iter().copied().enumerate() {
+    for (idx, pixel) in expected.iter().enumerate() {
+        let pixel = *pixel;
         let expected_color = match pixel {
             [0x00, 0x00, 0x00] => DMG_PALETTE[3],
             [0x55, 0x55, 0x55] => DMG_PALETTE[2],


### PR DESCRIPTION
## Summary
- update the PNG-based tests to iterate cached pixel slices by reference so the shared buffers are reused without extra copies

## Testing
- cargo clippy -p vibe-emu-core --tests -- -D warnings
- cargo fmt --all
- cargo test -p vibe-emu-core --test gambatte -- --nocapture
- cargo test -p vibe-emu-core --test dmg_sound_roms -- --nocapture
- cargo test -p vibe-emu-core --test dmg_acid2_rom -- --nocapture
- cargo test -p vibe-emu-core --test cgb_acid2_rom -- --nocapture
- cargo test -p vibe-emu-core --test halt_bug_rom -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d701dfe9f48325b1147fd5fa4f647a