### PR TITLE
fix: handle optional PNG buffer sizes

### DIFF
--- a/crates/vibe-emu-core/tests/common/mod.rs
+++ b/crates/vibe-emu-core/tests/common/mod.rs
@@ -78,7 +78,10 @@ pub fn load_png_rgb<P: AsRef<Path>>(path: P) -> (u32, u32, Arc<[[u8; 3]]>) {
     let mut decoder = png::Decoder::new(reader);
     decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
     let mut png_reader = decoder.read_info().expect("failed to read png info");
-    let mut buf = vec![0; png_reader.output_buffer_size()];
+    let buffer_size = png_reader
+        .output_buffer_size()
+        .expect("failed to get png output buffer size");
+    let mut buf = vec![0; buffer_size];
     let info = png_reader
         .next_frame(&mut buf)
         .expect("failed to decode png frame");

--- a/crates/vibe-emu-ui/src/main.rs
+++ b/crates/vibe-emu-ui/src/main.rs
@@ -28,7 +28,8 @@ fn load_window_icon() -> Option<Icon> {
     let mut decoder = png::Decoder::new(cursor);
     decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
     let mut reader = decoder.read_info().ok()?;
-    let mut buf = vec![0; reader.output_buffer_size()];
+    let buffer_size = reader.output_buffer_size()?;
+    let mut buf = vec![0; buffer_size];
     let info = reader.next_frame(&mut buf).ok()?;
     let data = &buf[..info.buffer_size()];
     let pixel_count = info.width as usize * info.height as usize;


### PR DESCRIPTION
## Summary
- handle optional PNG output buffer sizing in the UI window icon loader
- unwrap the PNG output buffer size in the shared test helper to surface I/O errors clearly

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test --lib`
- `cargo test --release --lib`
- `cargo test` *(aborted after confirming large Gambatte ROM suite begins running; integration suite exceeds task time window)*

------
https://chatgpt.com/codex/tasks/task_e_68debcf8e82c8325b4d9d2df81c26b81